### PR TITLE
Update GitHub Pages configuration and installation instructions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,8 @@ jobs:
   publish-dokka:
     name: Publish Dokka HTML
     runs-on: ubuntu-latest
+    env:
+      PAGES_TOKEN: ${{ secrets.PAGES_TOKEN }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -31,7 +33,15 @@ jobs:
           cache: gradle
       - name: Generate Dokka HTML
         run: ./gradlew dokkaGenerate
-      - uses: actions/configure-pages@v5
+      - name: Configure GitHub Pages
+        if: ${{ env.PAGES_TOKEN == '' }}
+        uses: actions/configure-pages@v5
+      - name: Configure GitHub Pages and enable site
+        if: ${{ env.PAGES_TOKEN != '' }}
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+          token: ${{ env.PAGES_TOKEN }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: build/dokka/html

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ flowchart LR
 
 ```kotlin
 repositories { maven("https://jitpack.io") }
-dependencies { debugImplementation("io.github.mohdaquib:scanner-ui:<version>") }
+dependencies { debugImplementation("com.github.mohdaquib.ComposeA11yScanner:scanner-ui:<tag>") }
 ```
 
 Use a debug-only dependency because the scanner is intended for development builds. `:scanner-ui` brings `:scanner-core` and `:scanner-rules` transitively.


### PR DESCRIPTION
- Modify `.github/workflows/docs.yml` to support an optional `PAGES_TOKEN` for GitHub Pages configuration.
- Add logic to explicitly enable site deployment and use the provided token in the CI workflow if `PAGES_TOKEN` is present.
- Update the JitPack dependency path in `README.md` to use the correct repository-based coordinates.