### PR TITLE
Update CI workflow name and add status badges to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Test
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Compose A11y Scanner
 
+[![Build and Test](https://github.com/mohdaquib/ComposeA11yScanner/actions/workflows/ci.yml/badge.svg)](https://github.com/mohdaquib/ComposeA11yScanner/actions/workflows/ci.yml)
+[![API Docs](https://github.com/mohdaquib/ComposeA11yScanner/actions/workflows/docs.yml/badge.svg)](https://github.com/mohdaquib/ComposeA11yScanner/actions/workflows/docs.yml)
+[![JitPack](https://jitpack.io/v/mohdaquib/ComposeA11yScanner.svg)](https://jitpack.io/#mohdaquib/ComposeA11yScanner)
+
 Runtime accessibility scanner that overlays issues directly on your Compose UI
 
 ![Annotated GIF showing the Compose A11y Scanner issue summary, view highlights, and issue detail sheet in the sample app](docs/overlay-demo.gif)


### PR DESCRIPTION
- Rename CI workflow from "CI" to "Build and Test".
- Add GitHub Actions badges for Build and Test workflow and API documentation.
- Add JitPack version badge to the README.