### PR TITLE
Fix stale scan results after screen changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ ComposeA11yScanner.install(
 
 Do not combine automatic and manual installation. Repeated installation on the same activity is ignored, but keeping one ownership path makes configuration predictable.
 
+For Navigation Compose, provide the current route when installing manually. An explicit key reliably
+invalidates stale results even when two destinations have the same semantics structure:
+
+```kotlin
+ComposeA11yScanner.install(
+    activity = this,
+    destinationKeyProvider = {
+        navController.currentBackStackEntry?.destination?.route
+    },
+)
+```
+
+If a navigation framework cannot expose a route provider, automatic host/semantics detection remains
+enabled. A custom navigator can also invalidate the current result explicitly:
+
+```kotlin
+ComposeA11yScanner.notifyScreenChanged()
+```
+
 ### Embedded scaffold
 
 `A11yScannerScaffold` is the advanced API for apps that want the scanner UI inside their own Compose hierarchy or need a custom node provider. It requires an `A11yScannerController`; most integrations should use the automatic activity overlay above.

--- a/scanner-rules/src/main/java/com/composea11yscanner/rules/DuplicateContentDescriptionRule.kt
+++ b/scanner-rules/src/main/java/com/composea11yscanner/rules/DuplicateContentDescriptionRule.kt
@@ -5,7 +5,7 @@ import com.composea11yscanner.core.model.A11yNode
 import com.composea11yscanner.core.model.A11ySeverity
 import com.composea11yscanner.core.rule.BaseScanRule
 
-/** Flags sibling-level nodes that reuse the same non-empty content description. */
+/** Flags independently exposed nodes that reuse a description in the same semantic scope. */
 class DuplicateContentDescriptionRule : BaseScanRule() {
 
     /** Stable id for the duplicate content description rule. */
@@ -20,19 +20,37 @@ class DuplicateContentDescriptionRule : BaseScanRule() {
     /** WCAG criterion associated with distinguishable labels. */
     override val wcagReference = "WCAG 2.4.6 Headings and Labels (Level AA)"
 
-    /** Evaluates all nodes together to find repeated labels among semantic siblings. */
-    override fun evaluateAll(nodes: List<A11yNode>): List<A11yIssue> =
-        nodes
+    /**
+     * Compares siblings outside collections and all items within the same semantic collection.
+     * Parent/child copies of one merged accessibility target are collapsed before grouping.
+     */
+    override fun evaluateAll(nodes: List<A11yNode>): List<A11yIssue> {
+        val nodesById = nodes.associateBy(A11yNode::nodeId)
+        val candidates = nodes
             .asSequence()
-            .filter { !it.contentDescription.isNullOrBlank() && !it.isMergedDescendant }
-            .groupBy { it.parentNodeId to it.contentDescription }
+            .filter { node ->
+                !node.contentDescription.isNullOrBlank() &&
+                    (!node.isMergedDescendant || node.isTouchTarget) &&
+                    node.isEnabled &&
+                    !node.bounds.isEmpty()
+            }
+            .toList()
+        val candidateIds = candidates.mapTo(mutableSetOf(), A11yNode::nodeId)
+
+        return candidates
+            .asSequence()
+            .filterNot { node -> node.isCopyOfLabeledAncestor(candidateIds, nodesById) }
+            .groupBy { node ->
+                val scopeId = node.nearestCollectionAncestorId(nodesById) ?: node.parentNodeId
+                scopeId to node.normalizedDescription()
+            }
             .filter { (_, group) -> group.size > 1 }
-            .flatMap { (key, group) ->
-                val text = key.second
+            .flatMap { (_, group) ->
+                val text = group.first().contentDescription!!.trim()
                 group.map { node ->
                     issue(
                         node = node,
-                        message = "Two elements share the same content description: '$text'. " +
+                        message = "Multiple elements share the same content description: '$text'. " +
                             "Screen readers may confuse users.",
                         howToFix = "Give each element a unique content description that " +
                             "identifies its specific action or content.",
@@ -40,4 +58,48 @@ class DuplicateContentDescriptionRule : BaseScanRule() {
                 }
             }
             .toList()
+    }
+
+    private fun A11yNode.nearestCollectionAncestorId(
+        nodesById: Map<String, A11yNode>,
+    ): String? {
+        var current = parentNodeId?.let(nodesById::get)
+        val visited = mutableSetOf<String>()
+        while (current != null && visited.add(current.nodeId)) {
+            if (current.isCollectionContainer) return current.nodeId
+            current = current.parentNodeId?.let(nodesById::get)
+        }
+        return null
+    }
+
+    private fun A11yNode.isCopyOfLabeledAncestor(
+        candidateIds: Set<String>,
+        nodesById: Map<String, A11yNode>,
+    ): Boolean {
+        val description = normalizedDescription()
+        var current = parentNodeId?.let(nodesById::get)
+        val visited = mutableSetOf<String>()
+        while (current != null && visited.add(current.nodeId)) {
+            if (
+                current.nodeId in candidateIds &&
+                current.normalizedDescription() == description &&
+                current.bounds.contains(bounds)
+            ) {
+                return true
+            }
+            current = current.parentNodeId?.let(nodesById::get)
+        }
+        return false
+    }
+
+    private fun A11yNode.normalizedDescription(): String =
+        contentDescription.orEmpty().trim().lowercase()
+
+    private fun com.composea11yscanner.core.model.Rect.contains(
+        other: com.composea11yscanner.core.model.Rect,
+    ): Boolean =
+        left <= other.left &&
+            top <= other.top &&
+            right >= other.right &&
+            bottom >= other.bottom
 }

--- a/scanner-rules/src/main/java/com/composea11yscanner/rules/MissingContentDescriptionRule.kt
+++ b/scanner-rules/src/main/java/com/composea11yscanner/rules/MissingContentDescriptionRule.kt
@@ -26,14 +26,15 @@ class MissingContentDescriptionRule : BaseA11yRule() {
         // They are not currently rendered or reachable, so do not report them.
         if (node.bounds.isEmpty()) return null
 
-        // Merged descendants are announced via their parent — skip them.
-        if (node.isMergedDescendant) return null
-
         val isInteractive = node.isTouchTarget
         // Covers Image, AsyncImage, SubcomposeAsyncImage, etc.
         val isImage = node.composableName.contains("Image", ignoreCase = true)
 
         if (!isInteractive && !isImage) return null
+        // A decorative image under merging semantics is announced through its parent. An
+        // interactive descendant, however, owns an action and remains an independent control;
+        // suppressing it hides unlabeled IconButtons such as JetSnack's collection arrows.
+        if (node.isMergedDescendant && !isInteractive) return null
         if (!node.contentDescription.isNullOrBlank()) return null
 
         return issue(

--- a/scanner-rules/src/test/java/com/composea11yscanner/rules/DuplicateContentDescriptionRuleTest.kt
+++ b/scanner-rules/src/test/java/com/composea11yscanner/rules/DuplicateContentDescriptionRuleTest.kt
@@ -159,4 +159,103 @@ class DuplicateContentDescriptionRuleTest {
 
         assertTrue(rule.evaluateAll(listOf(androidPicks, wfhFavourites)).isEmpty())
     }
+
+    @Test
+    fun `same action in different items of one collection is a duplicate`() {
+        val collection = createNode(
+            nodeId = "cart-list",
+            depth = 1,
+            isCollectionContainer = true,
+        )
+        val gingerbreadRow = createNode(
+            nodeId = "gingerbread-row",
+            parentNodeId = collection.nodeId,
+            depth = 2,
+        )
+        val kitkatRow = createNode(
+            nodeId = "kitkat-row",
+            parentNodeId = collection.nodeId,
+            depth = 2,
+        )
+        val removeGingerbread = createNode(
+            nodeId = "remove-gingerbread",
+            parentNodeId = gingerbreadRow.nodeId,
+            depth = 3,
+            bounds = Rect(0, 0, 100, 100),
+            contentDescription = "Remove",
+            isTouchTarget = true,
+            isMergedDescendant = true,
+        )
+        val removeKitkat = createNode(
+            nodeId = "remove-kitkat",
+            parentNodeId = kitkatRow.nodeId,
+            depth = 3,
+            bounds = Rect(0, 100, 100, 200),
+            contentDescription = "Remove",
+            isTouchTarget = true,
+            isMergedDescendant = true,
+        )
+
+        val issues = rule.evaluateAll(
+            listOf(
+                collection,
+                gingerbreadRow,
+                kitkatRow,
+                removeGingerbread,
+                removeKitkat,
+            ),
+        )
+
+        assertEquals(2, issues.size)
+        assertTrue(issues.all { it.message.contains("'Remove'") })
+    }
+
+    @Test
+    fun `same description in separate collections is not a duplicate`() {
+        val firstCollection = createNode(
+            nodeId = "first-list",
+            isCollectionContainer = true,
+        )
+        val secondCollection = createNode(
+            nodeId = "second-list",
+            isCollectionContainer = true,
+        )
+        val first = createNode(
+            nodeId = "first-action",
+            parentNodeId = firstCollection.nodeId,
+            bounds = Rect(0, 0, 100, 100),
+            contentDescription = "Open item",
+            isTouchTarget = true,
+        )
+        val second = createNode(
+            nodeId = "second-action",
+            parentNodeId = secondCollection.nodeId,
+            bounds = Rect(0, 100, 100, 200),
+            contentDescription = "Open item",
+            isTouchTarget = true,
+        )
+
+        assertTrue(
+            rule.evaluateAll(listOf(firstCollection, secondCollection, first, second)).isEmpty(),
+        )
+    }
+
+    @Test
+    fun `parent and child copies of one label are not duplicates`() {
+        val parent = createNode(
+            nodeId = "card",
+            bounds = Rect(0, 0, 200, 200),
+            contentDescription = "Cupcake A tag line",
+            isTouchTarget = true,
+        )
+        val child = createNode(
+            nodeId = "card-image",
+            parentNodeId = parent.nodeId,
+            depth = 1,
+            bounds = Rect(20, 20, 180, 180),
+            contentDescription = "Cupcake A tag line",
+        )
+
+        assertTrue(rule.evaluateAll(listOf(parent, child)).isEmpty())
+    }
 }

--- a/scanner-rules/src/test/java/com/composea11yscanner/rules/MissingContentDescriptionRuleTest.kt
+++ b/scanner-rules/src/test/java/com/composea11yscanner/rules/MissingContentDescriptionRuleTest.kt
@@ -29,11 +29,30 @@ class MissingContentDescriptionRuleTest {
     }
 
     @Test
-    fun `merged descendant with no description is skipped`() {
+    fun `merged decorative image with no description is skipped`() {
         assertNull(
             rule.evaluate(
-                createNode(isTouchTarget = true, contentDescription = null, isMergedDescendant = true)
+                createNode(
+                    composableName = "Image",
+                    isTouchTarget = false,
+                    contentDescription = null,
+                    isMergedDescendant = true,
+                ),
             )
+        )
+    }
+
+    @Test
+    fun `merged interactive node with no description fails`() {
+        assertNotNull(
+            rule.evaluate(
+                createNode(
+                    composableName = "Button",
+                    isTouchTarget = true,
+                    contentDescription = null,
+                    isMergedDescendant = true,
+                ),
+            ),
         )
     }
 

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -6,6 +6,7 @@ import android.graphics.Rect as AndroidRect
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.activity.ComponentActivity
 import androidx.compose.animation.AnimatedVisibility
@@ -41,8 +42,12 @@ import com.composea11yscanner.ui.A11yIssueOverlay
 import com.composea11yscanner.ui.A11yNodeExtractor
 import com.composea11yscanner.ui.A11yScannerController
 import com.composea11yscanner.ui.IssueDetailPanel
+import com.composea11yscanner.ui.ReadinessFingerprint
 import com.composea11yscanner.ui.RenderedTextContrastAnalyzer
 import com.composea11yscanner.ui.ScanSummaryBar
+import com.composea11yscanner.ui.ScreenFingerprint
+import com.composea11yscanner.ui.calculateReadinessFingerprint
+import com.composea11yscanner.ui.calculateScreenFingerprint
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -75,6 +80,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 object ComposeA11yScanner {
 
     private const val COMPOSE_HOST_LOG_TAG = "ComposeA11yHosts"
+    private const val SCAN_LIFECYCLE_LOG_TAG = "ComposeA11yLifecycle"
 
     /**
      * Active scanner entries keyed by activity. [LinkedHashMap] preserves insertion order so
@@ -110,6 +116,22 @@ object ComposeA11yScanner {
     fun install(
         activity: ComponentActivity,
         config: ScannerConfig = ScannerConfig(enabledRules = ScannerRules.allRuleIds().toSet()),
+    ) = installInternal(activity, config, destinationKeyProvider = null)
+
+    /**
+     * Installs the scanner with an explicit key for single-host Compose navigation.
+     * Return the current route, pane, or other stable destination identifier from the provider.
+     */
+    fun install(
+        activity: ComponentActivity,
+        destinationKeyProvider: () -> String?,
+        config: ScannerConfig = ScannerConfig(enabledRules = ScannerRules.allRuleIds().toSet()),
+    ) = installInternal(activity, config, destinationKeyProvider)
+
+    private fun installInternal(
+        activity: ComponentActivity,
+        config: ScannerConfig,
+        destinationKeyProvider: (() -> String?)?,
     ) {
         requireDebugBuild(activity)
         if (entries.containsKey(activity)) return
@@ -133,7 +155,16 @@ object ComposeA11yScanner {
         }
         activity.addContentView(overlayView, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
 
-        entries[activity] = InstallEntry(controller, overlayView)
+        val entry = InstallEntry(
+            controller = controller,
+            overlayView = overlayView,
+            autoScan = config.autoScan,
+            screenSnapshotProvider = {
+                activity.currentScreenSnapshot(destinationKeyProvider)
+            },
+        )
+        entries[activity] = entry
+        entry.attach()
         activeController.value = controller
         activity.lifecycle.addObserver(AutoUninstallObserver(activity))
     }
@@ -187,6 +218,12 @@ object ComposeA11yScanner {
         return entries.values.lastOrNull()?.controller?.startScan() ?: emptyFlow()
     }
 
+    /** Invalidates the current result and schedules a scan for the latest destination. */
+    fun notifyScreenChanged() {
+        requireDebugBuild()
+        entries.values.lastOrNull()?.notifyScreenChanged()
+    }
+
     // ── Debug guard ─────────────────────────────────────────────────────────────
 
     private fun requireDebugBuild(context: Context) {
@@ -221,7 +258,11 @@ object ComposeA11yScanner {
     // Compose semantics snapshot is immutable once produced on the main thread.
     // runCatching provides a last-resort safety net in case of unexpected threading issues.
     private fun extractNodes(activity: ComponentActivity): List<A11yNode> =
-        runCatching { extractNodesUnchecked(activity) }.getOrDefault(emptyList())
+        runCatching { extractNodesUnchecked(activity) }
+            .onFailure { error ->
+                Log.e(COMPOSE_HOST_LOG_TAG, "Failed to extract Compose semantics", error)
+            }
+            .getOrDefault(emptyList())
 
     private fun extractNodesUnchecked(activity: ComponentActivity): List<A11yNode> {
         val overlayView = entries[activity]?.overlayView
@@ -236,7 +277,43 @@ object ComposeA11yScanner {
                 "visibleTextNodes=${selectedHost.visibleTextNodes}, " +
                 "visibleNodes=${selectedHost.visibleNodes}, depth=${selectedHost.depth}",
         )
-        return RenderedTextContrastAnalyzer(selectedHost.view).analyze(selectedHost.nodes)
+        val semanticNodes = selectedHost.nodes
+        return runCatching {
+            RenderedTextContrastAnalyzer(selectedHost.view).analyze(semanticNodes)
+        }.onFailure { error ->
+            // Rendered contrast is an optional enrichment step. A bitmap capture or pixel-analysis
+            // failure must not discard the semantics tree and turn the whole scan into an empty
+            // 100% result; all non-visual rules can still evaluate the original nodes.
+            Log.w(
+                COMPOSE_HOST_LOG_TAG,
+                "Rendered text contrast analysis failed; scanning semantic nodes without colors",
+                error,
+            )
+        }.getOrDefault(semanticNodes)
+    }
+
+    private fun ComponentActivity.currentScreenSnapshot(
+        destinationKeyProvider: (() -> String?)?,
+    ): ScreenSnapshot? {
+        val overlayView = entries[this]?.overlayView
+        val decorView = window.decorView as? ViewGroup ?: return null
+        val candidate = decorView
+            .findBestAbstractComposeView(excludeView = overlayView, logScores = false)
+            ?: return null
+        // A newly attached ComposeView can expose only its root node before the destination has
+        // produced semantics. Treat that state as not ready instead of reporting an empty 100% scan.
+        if (candidate.nodes.none { it.depth > 0 }) return null
+        val destinationKey = destinationKeyProvider?.let { provider ->
+            runCatching(provider)
+                .onFailure { error ->
+                    Log.w(SCAN_LIFECYCLE_LOG_TAG, "Destination key provider failed", error)
+                }
+                .getOrNull()
+        }
+        return ScreenSnapshot(
+            fingerprint = candidate.screenFingerprint(destinationKey),
+            readiness = candidate.readinessFingerprint(),
+        )
     }
 
     private fun AbstractComposeView.findSemanticsOwner(): SemanticsOwner? {
@@ -250,6 +327,7 @@ object ComposeA11yScanner {
 
     private fun ViewGroup.findBestAbstractComposeView(
         excludeView: View?,
+        logScores: Boolean = true,
     ): ComposeHostCandidate? {
         val candidates = mutableListOf<ComposeHostCandidate>()
         collectComposeHostCandidates(
@@ -257,13 +335,15 @@ object ComposeA11yScanner {
             depth = 0,
             candidates = candidates,
         )
-        candidates.forEach { candidate ->
-            Log.d(
-                COMPOSE_HOST_LOG_TAG,
-                "Candidate score: identity=${System.identityHashCode(candidate.view)}, " +
-                    "visibleTextNodes=${candidate.visibleTextNodes}, " +
-                    "visibleNodes=${candidate.visibleNodes}, depth=${candidate.depth}",
-            )
+        if (logScores) {
+            candidates.forEach { candidate ->
+                Log.d(
+                    COMPOSE_HOST_LOG_TAG,
+                    "Candidate score: identity=${System.identityHashCode(candidate.view)}, " +
+                        "visibleTextNodes=${candidate.visibleTextNodes}, " +
+                        "visibleNodes=${candidate.visibleNodes}, depth=${candidate.depth}",
+                )
+            }
         }
         return candidates.maxWithOrNull(
             compareBy<ComposeHostCandidate> { it.visibleTextNodes }
@@ -309,8 +389,7 @@ object ComposeA11yScanner {
             view = this,
             nodes = nodes,
             depth = depth,
-            visibleTextNodes = visibleNodes.count { it.composableName == "Text" },
-            visibleNodes = visibleNodes.size,
+            visibleSemanticNodes = visibleNodes,
         )
     }
 
@@ -375,12 +454,176 @@ object ComposeA11yScanner {
     private class InstallEntry(
         val controller: A11yScannerController,
         val overlayView: ComposeView,
-    ) {
+        private val autoScan: Boolean,
+        private val screenSnapshotProvider: () -> ScreenSnapshot?,
+    ) : ViewTreeObserver.OnPreDrawListener {
+        private var baselineFingerprint: ScreenFingerprint? = null
+        private var completedScanId: String? = null
+        private var lastCheckUptimeMillis = 0L
+        private var pendingScreenFingerprint: ScreenFingerprint? = null
+        private var rescanRequestedAtUptimeMillis: Long? = null
+        private var pendingInitialReadiness: ReadinessFingerprint? = null
+        private var initialScanRequestedAtUptimeMillis: Long? = null
+        private val initialScanRunnable = object : Runnable {
+            override fun run() {
+                val now = android.os.SystemClock.uptimeMillis()
+                val deadlineReached = initialScanRequestedAtUptimeMillis?.let { requestedAt ->
+                    now - requestedAt >= MAX_INITIAL_SETTLE_MILLIS
+                } ?: true
+                val snapshot = screenSnapshotProvider()
+                if (snapshot == null && !deadlineReached) return scheduleInitialScanCheck()
+
+                val readiness = snapshot?.readiness
+                if (readiness != null && readiness != pendingInitialReadiness && !deadlineReached) {
+                    pendingInitialReadiness = readiness
+                    Log.d(
+                        SCAN_LIFECYCLE_LOG_TAG,
+                        "Initial semantics changed; waiting for a stable sample: $readiness",
+                    )
+                    return scheduleInitialScanCheck()
+                }
+
+                Log.d(
+                    SCAN_LIFECYCLE_LOG_TAG,
+                    if (deadlineReached) {
+                        "Initial settle deadline reached; starting scan"
+                    } else {
+                        "Initial host ready; starting scan"
+                    },
+                )
+                pendingInitialReadiness = null
+                initialScanRequestedAtUptimeMillis = null
+                controller.startScan()
+            }
+        }
+        private val rescanRunnable = object : Runnable {
+            override fun run() {
+                val expectedFingerprint = pendingScreenFingerprint ?: return
+                val now = android.os.SystemClock.uptimeMillis()
+                val deadlineReached = rescanRequestedAtUptimeMillis?.let { requestedAt ->
+                    now - requestedAt >= MAX_RESCAN_SETTLE_MILLIS
+                } ?: true
+                val currentFingerprint = screenSnapshotProvider()?.fingerprint
+
+                if (currentFingerprint == null && !deadlineReached) return scheduleRescan()
+                if (
+                    currentFingerprint != null &&
+                    currentFingerprint != expectedFingerprint &&
+                    !deadlineReached
+                ) {
+                    pendingScreenFingerprint = currentFingerprint
+                    return scheduleRescan()
+                }
+
+                Log.d(
+                    SCAN_LIFECYCLE_LOG_TAG,
+                    if (deadlineReached) {
+                        "Rescan settle deadline reached; starting scan"
+                    } else {
+                        "Destination stable; starting rescan"
+                    },
+                )
+                pendingScreenFingerprint = null
+                rescanRequestedAtUptimeMillis = null
+                controller.startScan()
+            }
+        }
+
+        fun attach() {
+            overlayView.rootView.viewTreeObserver.addOnPreDrawListener(this)
+            if (autoScan) requestInitialScan()
+        }
+
+        override fun onPreDraw(): Boolean {
+            val now = android.os.SystemClock.uptimeMillis()
+            if (now - lastCheckUptimeMillis < SCREEN_CHECK_INTERVAL_MILLIS) return true
+            lastCheckUptimeMillis = now
+
+            val complete = controller.currentState as? ScannerState.Complete
+            if (complete == null) {
+                completedScanId = null
+                baselineFingerprint = null
+                return true
+            }
+
+            val currentFingerprint = screenSnapshotProvider()?.fingerprint ?: return true
+            if (completedScanId != complete.result.scanId) {
+                completedScanId = complete.result.scanId
+                baselineFingerprint = currentFingerprint
+                Log.d(SCAN_LIFECYCLE_LOG_TAG, "Scan baseline recorded: $currentFingerprint")
+                return true
+            }
+
+            if (baselineFingerprint != currentFingerprint) {
+                Log.d(
+                    SCAN_LIFECYCLE_LOG_TAG,
+                    "Screen changed: previous=$baselineFingerprint, current=$currentFingerprint",
+                )
+                baselineFingerprint = null
+                completedScanId = null
+                controller.clearState()
+                if (autoScan) {
+                    pendingScreenFingerprint = currentFingerprint
+                    rescanRequestedAtUptimeMillis = android.os.SystemClock.uptimeMillis()
+                    scheduleRescan()
+                }
+            }
+            return true
+        }
+
+        private fun scheduleRescan() {
+            overlayView.removeCallbacks(rescanRunnable)
+            overlayView.postDelayed(rescanRunnable, RESCAN_SETTLE_DELAY_MILLIS)
+        }
+
+        private fun requestInitialScan() {
+            pendingInitialReadiness = screenSnapshotProvider()?.readiness
+            initialScanRequestedAtUptimeMillis = android.os.SystemClock.uptimeMillis()
+            scheduleInitialScanCheck()
+        }
+
+        fun notifyScreenChanged() {
+            Log.d(SCAN_LIFECYCLE_LOG_TAG, "Screen change explicitly notified")
+            baselineFingerprint = null
+            completedScanId = null
+            controller.clearState()
+            if (!autoScan) return
+
+            val currentFingerprint = screenSnapshotProvider()?.fingerprint
+            if (currentFingerprint == null) {
+                requestInitialScan()
+            } else {
+                pendingScreenFingerprint = currentFingerprint
+                rescanRequestedAtUptimeMillis = android.os.SystemClock.uptimeMillis()
+                scheduleRescan()
+            }
+        }
+
+        private fun scheduleInitialScanCheck() {
+            overlayView.removeCallbacks(initialScanRunnable)
+            overlayView.postDelayed(initialScanRunnable, RESCAN_SETTLE_DELAY_MILLIS)
+        }
+
         fun detach() {
+            val observer = overlayView.rootView.viewTreeObserver
+            if (observer.isAlive) observer.removeOnPreDrawListener(this)
+            overlayView.removeCallbacks(initialScanRunnable)
+            overlayView.removeCallbacks(rescanRunnable)
+            pendingScreenFingerprint = null
+            rescanRequestedAtUptimeMillis = null
+            pendingInitialReadiness = null
+            initialScanRequestedAtUptimeMillis = null
             overlayView.disposeComposition()
             (overlayView.parent as? ViewGroup)?.removeView(overlayView)
             controller.stopScan()
             controller.destroy()
+        }
+
+        private companion object {
+            const val SCREEN_CHECK_INTERVAL_MILLIS = 500L
+            const val RESCAN_SETTLE_DELAY_MILLIS = 300L
+            const val MAX_RESCAN_SETTLE_MILLIS = 1_500L
+            const val MAX_INITIAL_SETTLE_MILLIS = 1_500L
         }
     }
 
@@ -388,8 +631,33 @@ object ComposeA11yScanner {
         val view: AbstractComposeView,
         val nodes: List<A11yNode>,
         val depth: Int,
-        val visibleTextNodes: Int,
-        val visibleNodes: Int,
+        val visibleSemanticNodes: List<A11yNode>,
+    ) {
+        val visibleTextNodes: Int
+            get() = visibleSemanticNodes.count { it.composableName == "Text" }
+
+        val visibleNodes: Int
+            get() = visibleSemanticNodes.size
+
+        fun screenFingerprint(destinationKey: String?): ScreenFingerprint {
+            return calculateScreenFingerprint(
+                hostIdentity = System.identityHashCode(view),
+                nodes = nodes,
+                destinationKey = destinationKey,
+            )
+        }
+
+        fun readinessFingerprint(): ReadinessFingerprint {
+            return calculateReadinessFingerprint(
+                hostIdentity = System.identityHashCode(view),
+                visibleNodes = visibleSemanticNodes,
+            )
+        }
+    }
+
+    private data class ScreenSnapshot(
+        val fingerprint: ScreenFingerprint,
+        val readiness: ReadinessFingerprint,
     )
 
     private class AutoUninstallObserver(
@@ -424,17 +692,15 @@ private fun ScannerOverlayContent(
     LaunchedEffect(Unit) {
         controller.stateFlow.collect { state ->
             scannerState = state
-            if (state is ScannerState.Scanning) selectedIssues = emptyList()
+            if (state !is ScannerState.Complete) selectedIssues = emptyList()
         }
     }
 
     LaunchedEffect(config) {
         controller.configure(config)
         if (!config.autoScan) {
-            controller.stopScan()
-            return@LaunchedEffect
+            controller.clearState()
         }
-        controller.startScan()
     }
 
     val scanResult = (scannerState as? ScannerState.Complete)?.result

--- a/scanner-ui/src/main/java/com/composea11yscanner/ui/A11yScannerController.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ui/A11yScannerController.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Public SDK entry point for running accessibility scans.
@@ -47,6 +48,9 @@ class A11yScannerController(
     private val nodeProvider: () -> List<A11yNode>,
     private val screenDensity: Float,
 ) {
+    @Volatile
+    internal var currentState: ScannerState = ScannerState.Idle
+        private set
     private var config: ScannerConfig = ScannerConfig(
         enabledRules = ScannerRules.allRuleIds().toSet(),
     )
@@ -55,6 +59,7 @@ class A11yScannerController(
     // SupervisorJob: a rule exception cancels only the current scan job, not the whole scope.
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var scanJob: Job? = null
+    private val scanGeneration = AtomicLong(0L)
 
     // replay = 1 so late subscribers immediately receive the latest state.
     // 64 extra slots is orders of magnitude more than needed (≤ ~10 states per scan),
@@ -106,10 +111,13 @@ class A11yScannerController(
      * and late subscribers receive the most recent state immediately via replay.
      *
      * Emission sequence: Scanning(0f) → Scanning(k/n) … → Scanning(1f) → Complete(result)
-     * or Complete(emptyResult) if there are no enabled rules or no nodes.
+     * or [ScannerState.Error] if no semantics nodes are available.
      */
     fun startScan(): Flow<ScannerState> {
-        stopScan()
+        val generation = scanGeneration.incrementAndGet()
+        cancelCurrentJob()
+        currentState = ScannerState.Scanning(0f)
+        _state.tryEmit(currentState)
 
         val standardRules = ScannerRules.buildRules(config, screenDensity)
 
@@ -128,7 +136,21 @@ class A11yScannerController(
             val nodes = withContext(Dispatchers.Main.immediate) {
                 nodeProvider()
             }
-            engine.scan(nodes).collect { _state.emit(it) }
+            if (generation != scanGeneration.get()) return@launch
+            if (nodes.isEmpty()) {
+                val state = ScannerState.Error(
+                    "No Compose semantics nodes were available for scanning. " +
+                        "Wait until the screen is laid out and try again.",
+                )
+                currentState = state
+                _state.emit(state)
+                return@launch
+            }
+            engine.scan(nodes).collect { state ->
+                if (generation != scanGeneration.get()) return@collect
+                currentState = state
+                _state.emit(state)
+            }
         }
 
         return _state.asSharedFlow()
@@ -136,18 +158,26 @@ class A11yScannerController(
 
     /** Stops any active scan and emits [ScannerState.Idle]. */
     fun clearState() {
-        stopScan()
+        scanGeneration.incrementAndGet()
+        cancelCurrentJob()
+        currentState = ScannerState.Idle
         _state.tryEmit(ScannerState.Idle)
     }
 
     /** Cancels the current scan if one is running. The [Flow] returned by [startScan] stops emitting. */
     fun stopScan() {
+        scanGeneration.incrementAndGet()
+        cancelCurrentJob()
+    }
+
+    private fun cancelCurrentJob() {
         scanJob?.cancel()
         scanJob = null
     }
 
     /** Cancels the internal [CoroutineScope]. Call when the host (Activity/Fragment/ViewModel) is destroyed. */
     fun destroy() {
+        stopScan()
         scope.cancel()
     }
 }

--- a/scanner-ui/src/main/java/com/composea11yscanner/ui/A11yScannerScaffold.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ui/A11yScannerScaffold.kt
@@ -73,7 +73,7 @@ fun A11yScannerScaffold(
     LaunchedEffect(Unit) {
         scannerController.stateFlow.collect { state ->
             scannerState = state
-            if (state is ScannerState.Scanning) selectedIssues = emptyList()
+            if (state !is ScannerState.Complete) selectedIssues = emptyList()
         }
     }
 

--- a/scanner-ui/src/main/java/com/composea11yscanner/ui/ScanSummaryBar.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ui/ScanSummaryBar.kt
@@ -84,11 +84,16 @@ fun ScanSummaryBar(
 ) {
     var showReport by remember { mutableStateOf(false) }
 
-    // Retain last complete result so the sheet stays populated when state rolls
-    // back to Idle while the sheet is still open.
+    // Retain the result during non-idle transitions, but discard it when content invalidation
+    // returns the scanner to Idle so a report from the previous screen cannot remain open.
     var lastResult by remember { mutableStateOf<ScanResult?>(null) }
     LaunchedEffect(state) {
-        if (state is ScannerState.Complete) lastResult = state.result
+        if (state is ScannerState.Complete) {
+            lastResult = state.result
+        } else if (state is ScannerState.Idle) {
+            lastResult = null
+            showReport = false
+        }
     }
 
     Surface(

--- a/scanner-ui/src/main/java/com/composea11yscanner/ui/ScreenIdentity.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ui/ScreenIdentity.kt
@@ -1,0 +1,90 @@
+package com.composea11yscanner.ui
+
+import com.composea11yscanner.core.model.A11yNode
+
+private const val SCREEN_IDENTITY_MAX_DEPTH = 3
+
+/** Readable, collision-resistant identity for the currently displayed destination. */
+internal data class ScreenFingerprint(
+    val hostIdentity: Int,
+    val destinationKey: String?,
+    val shallowNodeShapes: List<SemanticNodeShape>,
+)
+
+/** Stable semantics characteristics that survive recomposition and sibling reordering. */
+internal data class SemanticNodeShape(
+    val depth: Int,
+    val composableName: String,
+    val role: String?,
+    val isFocusable: Boolean,
+    val isTouchTarget: Boolean,
+    val isCollectionContainer: Boolean,
+) : Comparable<SemanticNodeShape> {
+    override fun compareTo(other: SemanticNodeShape): Int =
+        compareValuesBy(
+            this,
+            other,
+            SemanticNodeShape::depth,
+            SemanticNodeShape::composableName,
+            { it.role.orEmpty() },
+            SemanticNodeShape::isFocusable,
+            SemanticNodeShape::isTouchTarget,
+            SemanticNodeShape::isCollectionContainer,
+        )
+}
+
+/** Lightweight sample used to decide when initial visible semantics have settled. */
+internal data class ReadinessFingerprint(
+    val hostIdentity: Int,
+    val visibleNodeCount: Int,
+    val visibleTextNodeCount: Int,
+    val visibleInteractiveNodeCount: Int,
+    val visibleFocusableNodeCount: Int,
+)
+
+/**
+ * Creates a stable destination identity while ignoring volatile deep content.
+ *
+ * An explicit navigation key is authoritative when supplied. Otherwise Fragment transitions are
+ * detected by [hostIdentity] and single-host Compose transitions are inferred from the
+ * order-independent shape of the shallow semantics tree. Generated semantics IDs, text, bounds,
+ * and lazy descendants are deliberately excluded.
+ */
+internal fun calculateScreenFingerprint(
+    hostIdentity: Int,
+    nodes: List<A11yNode>,
+    destinationKey: String? = null,
+): ScreenFingerprint = ScreenFingerprint(
+    hostIdentity = hostIdentity,
+    destinationKey = destinationKey,
+    shallowNodeShapes = if (destinationKey != null) {
+        emptyList()
+    } else {
+        nodes.asSequence()
+            .filter { it.depth <= SCREEN_IDENTITY_MAX_DEPTH }
+            .map { node ->
+                SemanticNodeShape(
+                    depth = node.depth,
+                    composableName = node.composableName,
+                    role = node.role?.name,
+                    isFocusable = node.isFocusable,
+                    isTouchTarget = node.isTouchTarget,
+                    isCollectionContainer = node.isCollectionContainer,
+                )
+            }
+            .sorted()
+            .toList()
+    },
+)
+
+/** Creates an animation-resistant readiness sample from already-visible semantic nodes. */
+internal fun calculateReadinessFingerprint(
+    hostIdentity: Int,
+    visibleNodes: List<A11yNode>,
+): ReadinessFingerprint = ReadinessFingerprint(
+    hostIdentity = hostIdentity,
+    visibleNodeCount = visibleNodes.size,
+    visibleTextNodeCount = visibleNodes.count { it.composableName == "Text" },
+    visibleInteractiveNodeCount = visibleNodes.count(A11yNode::isTouchTarget),
+    visibleFocusableNodeCount = visibleNodes.count(A11yNode::isFocusable),
+)

--- a/scanner-ui/src/test/java/com/composea11yscanner/ui/ScreenIdentityTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ui/ScreenIdentityTest.kt
@@ -1,0 +1,116 @@
+package com.composea11yscanner.ui
+
+import com.composea11yscanner.core.model.A11yNode
+import com.composea11yscanner.core.model.Rect
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ScreenIdentityTest {
+
+    @Test
+    fun `deep dynamic content does not change screen fingerprint`() {
+        val original = listOf(node("root", depth = 0), node("message-1", depth = 5))
+        val updated = listOf(node("root", depth = 0), node("message-2", depth = 5))
+
+        assertEquals(
+            calculateScreenFingerprint(hostIdentity = 1, nodes = original),
+            calculateScreenFingerprint(hostIdentity = 1, nodes = updated),
+        )
+    }
+
+    @Test
+    fun `semantics ids recreated by recomposition do not change screen fingerprint`() {
+        val original = listOf(node("root-1", depth = 0), node("content-1", depth = 2, name = "Text"))
+        val recomposed = listOf(node("root-9", depth = 0), node("content-7", depth = 2, name = "Text"))
+
+        assertEquals(
+            calculateScreenFingerprint(hostIdentity = 1, nodes = original),
+            calculateScreenFingerprint(hostIdentity = 1, nodes = recomposed),
+        )
+    }
+
+    @Test
+    fun `shallow compose destination shape produces new screen fingerprint`() {
+        val conversation = listOf(node("root", depth = 0), node("messages", depth = 2, name = "Text"))
+        val profile = listOf(node("root", depth = 0), node("profile-action", depth = 2, name = "Button"))
+
+        assertNotEquals(
+            calculateScreenFingerprint(hostIdentity = 1, nodes = conversation),
+            calculateScreenFingerprint(hostIdentity = 1, nodes = profile),
+        )
+    }
+
+    @Test
+    fun `explicit destination key detects structurally identical compose screens`() {
+        val nodes = listOf(node("root", depth = 0), node("content", depth = 2, name = "Text"))
+
+        assertNotEquals(
+            calculateScreenFingerprint(hostIdentity = 1, nodes = nodes, destinationKey = "home"),
+            calculateScreenFingerprint(hostIdentity = 1, nodes = nodes, destinationKey = "search"),
+        )
+    }
+
+    @Test
+    fun `compose host replacement produces new screen fingerprint`() {
+        val nodes = listOf(node("root", depth = 0))
+
+        assertNotEquals(
+            calculateScreenFingerprint(hostIdentity = 1, nodes = nodes),
+            calculateScreenFingerprint(hostIdentity = 2, nodes = nodes),
+        )
+    }
+
+    @Test
+    fun `shallow sibling reordering does not change screen fingerprint`() {
+        val original = listOf(
+            node("root", depth = 0),
+            node("title", depth = 2, name = "Text"),
+            node("action", depth = 2, name = "Button"),
+        )
+        val reordered = listOf(original[0], original[2], original[1])
+
+        assertEquals(
+            calculateScreenFingerprint(hostIdentity = 1, nodes = original),
+            calculateScreenFingerprint(hostIdentity = 1, nodes = reordered),
+        )
+    }
+
+    @Test
+    fun `readiness ignores ids and exact bounds but observes visible node counts`() {
+        val first = listOf(node("one", depth = 1), node("two", depth = 2, name = "Text"))
+        val animated = listOf(
+            node("nine", depth = 1, bounds = Rect(10, 10, 90, 90)),
+            node("ten", depth = 2, name = "Text", bounds = Rect(20, 20, 80, 80)),
+        )
+        val populated = animated + node("button", depth = 4, name = "Button", isTouchTarget = true)
+
+        assertEquals(
+            calculateReadinessFingerprint(hostIdentity = 1, visibleNodes = first),
+            calculateReadinessFingerprint(hostIdentity = 1, visibleNodes = animated),
+        )
+        assertNotEquals(
+            calculateReadinessFingerprint(hostIdentity = 1, visibleNodes = animated),
+            calculateReadinessFingerprint(hostIdentity = 1, visibleNodes = populated),
+        )
+    }
+
+    private fun node(
+        id: String,
+        depth: Int,
+        name: String = "Unknown",
+        bounds: Rect = Rect(0, 0, 100, 100),
+        isTouchTarget: Boolean = false,
+    ): A11yNode = A11yNode(
+        nodeId = id,
+        composableName = name,
+        bounds = bounds,
+        contentDescription = null,
+        isTouchTarget = isTouchTarget,
+        textColor = null,
+        backgroundColors = emptyList(),
+        isFocusable = isTouchTarget,
+        isMergedDescendant = false,
+        depth = depth,
+    )
+}


### PR DESCRIPTION
- detect destination changes using navigation keys and semantic fingerprints
- clear outdated results and rescan after the new screen settles
- prevent cancelled scans from emitting stale state
- improve empty-scan and contrast-analysis error handling
- refine content-description checks for merged controls and collections