### PR TITLE
Fix scan summary bar positioning

### DIFF
--- a/sample/src/main/java/com/composea11yscanner/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/composea11yscanner/sample/SampleActivity.kt
@@ -124,6 +124,7 @@ fun BrokenAccessibilitySampleApp(modifier: Modifier = Modifier) {
         config = scannerConfig,
         modifier = modifier.fillMaxSize(),
         issueOffsetY = issueOffsetY,
+        summaryBarTopOffset = 64.dp,
     ) {
         Scaffold(
             modifier = Modifier.fillMaxSize(),
@@ -147,6 +148,9 @@ fun BrokenAccessibilitySampleApp(modifier: Modifier = Modifier) {
             SampleContent(
                 modifier = Modifier
                     .padding(innerPadding)
+                    // Keep this space stable so showing the scan summary never moves content
+                    // after the semantics bounds used by issue overlays have been captured.
+                    .padding(top = 56.dp)
                     .fillMaxSize(),
                 screens = screens,
                 selectedScreen = selectedScreen,

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -718,6 +719,7 @@ private fun ScannerOverlayContent(
             exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut(),
             modifier = Modifier
                 .align(Alignment.TopCenter)
+                .statusBarsPadding()
                 .fillMaxWidth(),
         ) {
             ScanSummaryBar(

--- a/scanner-ui/src/main/java/com/composea11yscanner/ui/A11yScannerScaffold.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ui/A11yScannerScaffold.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.composea11yscanner.core.model.A11yIssue
 import com.composea11yscanner.core.model.A11yNode
@@ -52,6 +54,8 @@ import com.composea11yscanner.core.model.ScannerState
  * @param config Scanner configuration applied to the controller.
  * @param modifier Modifier applied to the root scaffold.
  * @param issueOffsetY Vertical offset applied to issue highlights.
+ * @param summaryBarTopOffset Additional distance between the status bar and the scan summary.
+ * Use this when host content has a top app bar that must remain visible while scan results are shown.
  * @param content Host UI content being scanned.
  */
 @Composable
@@ -60,6 +64,7 @@ fun A11yScannerScaffold(
     config: ScannerConfig,
     modifier: Modifier = Modifier,
     issueOffsetY: Int = 0,
+    summaryBarTopOffset: Dp = 0.dp,
     content: @Composable () -> Unit,
 ) {
     var scannerState by remember { mutableStateOf<ScannerState>(ScannerState.Idle) }
@@ -108,6 +113,8 @@ fun A11yScannerScaffold(
             exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut(),
             modifier = Modifier
                 .align(Alignment.TopCenter)
+                .statusBarsPadding()
+                .padding(top = summaryBarTopOffset)
                 .fillMaxWidth(),
         ) {
             ScanSummaryBar(
@@ -159,6 +166,7 @@ private fun A11yScannerScaffoldCompletePreview() {
                 state = ScannerState.Complete(result = previewScanResult()),
                 modifier = Modifier
                     .align(Alignment.TopCenter)
+                    .statusBarsPadding()
                     .fillMaxWidth(),
             )
         }


### PR DESCRIPTION
- respect status bar insets in overlay and scaffold modes
- add a configurable top offset for host app bars
- keep sample content stable when scan results appear