### PR TITLE
Make scanner lifecycle explicit and production-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ ComposeA11yScanner.install(
 )
 ```
 
-Do not combine automatic and manual installation. Repeated installation on the same activity is ignored, but keeping one ownership path makes configuration predictable.
+Do not combine automatic and manual installation. Repeated installation on the same activity is
+ignored, but keeping one ownership path makes configuration predictable. With multiple manual
+activities, global APIs target the latest surviving installation and fall back after removal.
 
 For Navigation Compose, provide the current route when installing manually. An explicit key reliably
 invalidates stale results even when two destinations have the same semantics structure:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ problems that are not available from the Compose semantics tree alone.
 [![API Docs](https://github.com/mohdaquib/ComposeA11yScanner/actions/workflows/docs.yml/badge.svg)](https://mohdaquib.github.io/ComposeA11yScanner/)
 [![JitPack](https://jitpack.io/v/mohdaquib/ComposeA11yScanner.svg)](https://jitpack.io/#mohdaquib/ComposeA11yScanner)
 
-ComposeA11yScanner is a debug-only runtime scanner that finds accessibility issues in Jetpack
-Compose and highlights them directly on the rendered UI. Inspect the affected element, understand
-the problem, and see a suggested fix without leaving the app.
+ComposeA11yScanner is a debug-first runtime scanner that finds accessibility issues in Jetpack
+Compose and highlights them directly on the rendered UI. Non-debuggable builds are denied by
+default and can opt in explicitly for trusted internal use.
 
 ![Annotated GIF showing the Compose A11y Scanner issue summary, view highlights, and issue detail sheet in the sample app](docs/overlay-demo.gif)
 
@@ -22,8 +22,8 @@ the problem, and see a suggested fix without leaving the app.
 - **Semantics and rendered analysis** - rules inspect Compose semantics, while text contrast is
   estimated from a captured Compose host.
 - **Actionable guidance** - every finding includes its severity, WCAG reference, and a suggested fix.
-- **Minimal setup** - add one debug dependency; AndroidX Startup handles installation.
-- **Debug-only integration** - `debugImplementation` keeps the scanner out of release builds.
+- **Minimal setup** - AndroidX Startup handles activity tracking and installation.
+- **Default-deny integration** - debug builds work automatically; trusted builds must opt in.
 - **Extensible rules** - use the bundled rules or add checks for your own accessibility standards.
 
 ## What's new in 2.1.0
@@ -80,8 +80,31 @@ That is all the integration required. AndroidX Startup attaches the overlay and 
 scan for every `ComponentActivity` in a debuggable app.
 
 > [!IMPORTANT]
-> Keep the dependency and all direct scanner calls in debug source sets. Do not add the scanner
-> with `implementation` or reference it from release sources.
+> `debugImplementation` remains the recommended setup and keeps scanner code out of release builds.
+
+### Trusted non-debuggable builds
+
+Use `implementation` only when a trusted internal build must run the scanner without being
+Android-debuggable:
+
+```kotlin
+dependencies {
+    implementation("com.github.mohdaquib.ComposeA11yScanner:scanner-ui:<version>")
+}
+```
+
+Enable or disable it from the main thread whenever the environment changes:
+
+```kotlin
+ComposeA11yScanner.toggleScanner(enabled = endpoint != PROD)
+```
+
+AndroidX Startup must remain enabled. Calling `toggleScanner(true)` before an activity resumes
+installs on resume; calling it afterward installs immediately on every resumed activity. Calling
+`toggleScanner(false)` removes non-debuggable overlays, while debuggable builds remain enabled.
+
+If AndroidX Startup is removed for manual installation, `toggleScanner(true)` only grants
+permission; the app must still call `install()` for each activity.
 
 ### 2. Trigger a scan
 
@@ -112,8 +135,8 @@ fun App() {
 ```
 
 All built-in rules are enabled by default, and the overlay is removed when its activity is destroyed.
-Keep direct scanner imports in `src/debug`; dependencies added with `debugImplementation` are
-intentionally unavailable to release source sets.
+For debug-only integration, keep direct scanner imports in `src/debug`; dependencies added with
+`debugImplementation` are intentionally unavailable to release source sets.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ default and can opt in explicitly for trusted internal use.
   estimated from a captured Compose host.
 - **Actionable guidance** - every finding includes its severity, WCAG reference, and a suggested fix.
 - **Minimal setup** - AndroidX Startup handles activity tracking and installation.
-- **Default-deny integration** - debug builds work automatically; trusted builds must opt in.
+- **Default-deny integration** - debug builds work automatically unless explicitly disabled; trusted builds must opt in.
 - **Extensible rules** - use the bundled rules or add checks for your own accessibility standards.
 
 ## What's new in 2.1.0
@@ -76,11 +76,26 @@ dependencies {
 }
 ```
 
-That is all the integration required. AndroidX Startup attaches the overlay and runs an initial
-scan for every `ComponentActivity` in a debuggable app.
+That is all the integration required. The merged scanner manifest declares an AndroidX Startup
+initializer that runs before `Application.onCreate`, registers activity lifecycle callbacks, and
+attaches the overlay for every resumed `ComponentActivity` in a debuggable app.
 
 > [!IMPORTANT]
 > `debugImplementation` remains the recommended setup and keeps scanner code out of release builds.
+
+### Automatic startup and scanner availability
+
+Before the first `toggleScanner()` call, debuggable builds are enabled automatically and
+non-debuggable builds are denied. `toggleScanner(true)` enables every build; `toggleScanner(false)`
+removes every scanner overlay and blocks automatic installation, manual installation, and public
+scan APIs in every build until enabled again.
+
+Apps whose policy defaults to disabled must call `toggleScanner(false)` synchronously from
+`Application.onCreate`, before the first activity resumes. Do not wait for asynchronous endpoint,
+account, or remote-config resolution: a debuggable activity may otherwise install and auto-scan
+first. Runtime disable intentionally keeps the Startup callbacks registered and tracks resumed
+activities so `toggleScanner(true)` can install immediately. Use the [hard opt-out](#hard-opt-out-disable-automatic-initialization)
+when a variant must perform no scanner startup or activity-tracking work.
 
 ### Trusted non-debuggable builds
 
@@ -93,7 +108,7 @@ dependencies {
 }
 ```
 
-Enable or disable it from the main thread whenever the consuming app's trusted-build policy changes:
+Override scanner availability from the main thread whenever the consuming app's policy changes:
 
 ```kotlin
 ComposeA11yScanner.toggleScanner(enabled = scannerAllowed)
@@ -101,13 +116,9 @@ ComposeA11yScanner.toggleScanner(enabled = scannerAllowed)
 
 `scannerAllowed` is owned by the consuming app and should default to `false`. Derive it from a
 positive allowlist and prefer an internal flavor/source set when available. The library does not
-know about the consuming app's endpoints or build policy. AndroidX Startup
-must remain enabled. Calling `toggleScanner(true)` before an activity resumes
-installs on resume; calling it afterward installs immediately on every resumed activity. Calling
-`toggleScanner(false)` removes non-debuggable overlays, while debuggable builds remain enabled.
-
-If AndroidX Startup is removed for manual installation, `toggleScanner(true)` only grants
-permission; the app must still call `install()` for each activity.
+know about the consuming app's endpoints or build policy. Calling `toggleScanner(true)` before an
+activity resumes installs on resume; calling it afterward installs immediately on every tracked
+resumed activity.
 
 ### 2. Trigger a scan
 
@@ -155,22 +166,10 @@ For debug-only integration, keep direct scanner imports in `src/debug`; dependen
 
 ## Configuration
 
-Optional manifest metadata controls the auto-installed scanner:
+### Hard opt-out: disable automatic initialization
 
-```xml
-<application>
-    <meta-data
-        android:name="a11y_scanner_min_contrast"
-        android:value="4.5" />
-    <meta-data
-        android:name="a11y_scanner_auto_scan"
-        android:value="false" />
-</application>
-```
-
-### Manual installation
-
-Use manual installation only when you need a programmatic `ScannerConfig`. First disable the automatic initializer in the app manifest:
+For a variant that must perform no scanner startup, metadata reads, lifecycle callback registration,
+or activity tracking, remove the scanner initializer in that variant's manifest:
 
 ```xml
 <manifest xmlns:tools="http://schemas.android.com/tools">
@@ -187,7 +186,29 @@ Use manual installation only when you need a programmatic `ScannerConfig`. First
 </manifest>
 ```
 
-Then install after `setContent`:
+This prevents AndroidX Startup from discovering `A11yScannerInitializer`. With the initializer
+removed, `toggleScanner(true)` only grants permission; the app must call `install()` manually for
+each activity.
+
+### Automatic scanner configuration
+
+Optional manifest metadata controls the auto-installed scanner:
+
+```xml
+<application>
+    <meta-data
+        android:name="a11y_scanner_min_contrast"
+        android:value="4.5" />
+    <meta-data
+        android:name="a11y_scanner_auto_scan"
+        android:value="false" />
+</application>
+```
+
+### Manual installation
+
+Use manual installation only when you need a programmatic `ScannerConfig`. Apply the hard opt-out
+above, then install after `setContent`:
 
 ```kotlin
 setContent { App() }

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ permission; the app must still call `install()` for each activity.
 
 ### 2. Trigger a scan
 
-Call the API from a debug source set, such as `src/debug/java/.../ScannerActions.kt`:
+For debug-only integration, call the API from `src/debug`. For trusted non-debuggable builds,
+place the trigger in `src/main` or the trusted variant's source set:
 
 ```kotlin
 import com.composea11yscanner.ComposeA11yScanner
@@ -122,7 +123,8 @@ its state.
 
 ### Optional: shake to scan
 
-Add `scanOnShake()` to a debug-only composable that remains active while the screen is visible:
+Add `scanOnShake()` to a composable compiled into the enabled variant: `src/debug` for debug-only
+integration, or `src/main`/the trusted source set for non-debuggable integration:
 
 ```kotlin
 import com.composea11yscanner.triggers.scanOnShake

--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ import com.composea11yscanner.ComposeA11yScanner
 ComposeA11yScanner.triggerScan()
 ```
 
+Trusted builds must invoke direct triggers only while the same `scannerEnabled` value passed to
+`toggleScanner()` is true:
+
+```kotlin
+if (scannerEnabled) ComposeA11yScanner.triggerScan()
+```
+
 `ComposeA11yScanner.scan()` is safe to collect before the first activity reaches `onResume` when
 automatic installation is enabled. The flow waits for an installed activity scanner, then forwards
 its state.
@@ -131,10 +138,13 @@ import com.composea11yscanner.triggers.scanOnShake
 
 @Composable
 fun App() {
-    scanOnShake()
+    scanOnShake(enabled = scannerEnabled)
     AppContent()
 }
 ```
+
+For trusted builds, derive `scannerEnabled` from the same condition passed to `toggleScanner()` so
+triggers stop before production permission is disabled.
 
 All built-in rules are enabled by default, and the overlay is removed when its activity is destroyed.
 For debug-only integration, keep direct scanner imports in `src/debug`; dependencies added with

--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ dependencies {
 Enable or disable it from the main thread whenever the environment changes:
 
 ```kotlin
-ComposeA11yScanner.toggleScanner(enabled = endpoint != PROD)
+ComposeA11yScanner.toggleScanner(enabled = endpoint == DEV || endpoint == TEST)
 ```
 
-AndroidX Startup must remain enabled. Calling `toggleScanner(true)` before an activity resumes
+Use a positive allowlist and prefer an internal flavor/source set when available. AndroidX Startup
+must remain enabled. Calling `toggleScanner(true)` before an activity resumes
 installs on resume; calling it afterward installs immediately on every resumed activity. Calling
 `toggleScanner(false)` removes non-debuggable overlays, while debuggable builds remain enabled.
 

--- a/README.md
+++ b/README.md
@@ -93,13 +93,15 @@ dependencies {
 }
 ```
 
-Enable or disable it from the main thread whenever the environment changes:
+Enable or disable it from the main thread whenever the consuming app's trusted-build policy changes:
 
 ```kotlin
-ComposeA11yScanner.toggleScanner(enabled = endpoint == DEV || endpoint == TEST)
+ComposeA11yScanner.toggleScanner(enabled = scannerAllowed)
 ```
 
-Use a positive allowlist and prefer an internal flavor/source set when available. AndroidX Startup
+`scannerAllowed` is owned by the consuming app and should default to `false`. Derive it from a
+positive allowlist and prefer an internal flavor/source set when available. The library does not
+know about the consuming app's endpoints or build policy. AndroidX Startup
 must remain enabled. Calling `toggleScanner(true)` before an activity resumes
 installs on resume; calling it afterward installs immediately on every resumed activity. Calling
 `toggleScanner(false)` removes non-debuggable overlays, while debuggable builds remain enabled.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ mockk = "1.13.12"
 turbine = "1.2.0"
 detekt = "1.23.7"
 paparazzi = "2.0.0-alpha05"
+robolectric = "4.13"
+androidxTestCore = "1.6.1"
 dokka = "2.2.0"
 
 [libraries]
@@ -21,6 +23,8 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-startup-runtime = { group = "androidx.startup", name = "startup-runtime", version.ref = "appStartup" }

--- a/scanner-ui/build.gradle.kts
+++ b/scanner-ui/build.gradle.kts
@@ -29,6 +29,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
     buildFeatures { compose = true }
+    testOptions.unitTests.isIncludeAndroidResources = true
 }
 
 kotlin {
@@ -59,6 +60,8 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
@@ -6,9 +6,13 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
 import androidx.startup.Initializer
 import com.composea11yscanner.core.model.ScannerConfig
 import com.composea11yscanner.rules.ScannerRules
+
+internal fun canResume(destroyed: Boolean, state: Lifecycle.State): Boolean =
+    !destroyed && state.isAtLeast(Lifecycle.State.RESUMED)
 
 /**
  * AndroidX App Startup initializer for installing [ComposeA11yScanner] in allowed builds.
@@ -38,7 +42,11 @@ class A11yScannerInitializer : Initializer<Unit> {
                 override fun onActivityResumed(activity: Activity) {
                     val componentActivity = activity as? ComponentActivity ?: return
                     componentActivity.window.decorView.post {
-                        if (componentActivity.isDestroyed) return@post
+                        val resumed = canResume(
+                            componentActivity.isDestroyed,
+                            componentActivity.lifecycle.currentState,
+                        )
+                        if (!resumed) return@post
                         ComposeA11yScanner.resume(componentActivity, config)
                     }
                 }
@@ -50,7 +58,9 @@ class A11yScannerInitializer : Initializer<Unit> {
                 }
                 override fun onActivityStopped(activity: Activity) = Unit
                 override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
-                override fun onActivityDestroyed(activity: Activity) = Unit
+                override fun onActivityDestroyed(activity: Activity) {
+                    (activity as? ComponentActivity)?.let(ComposeA11yScanner::pause)
+                }
             },
         )
     }

--- a/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
@@ -59,7 +59,7 @@ class A11yScannerInitializer : Initializer<Unit> {
                 override fun onActivityStopped(activity: Activity) = Unit
                 override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
                 override fun onActivityDestroyed(activity: Activity) {
-                    (activity as? ComponentActivity)?.let(ComposeA11yScanner::destroy)
+                    (activity as? ComponentActivity)?.let(ComposeA11yScanner::pause)
                 }
             },
         )

--- a/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
@@ -15,7 +15,10 @@ internal fun canResume(destroyed: Boolean, state: Lifecycle.State): Boolean =
     !destroyed && state.isAtLeast(Lifecycle.State.RESUMED)
 
 /**
- * AndroidX App Startup initializer for installing [ComposeA11yScanner] in allowed builds.
+ * AndroidX App Startup initializer for installing [ComposeA11yScanner] in allowed builds. It is
+ * declared by the scanner manifest, runs before `Application.onCreate`, and registers activity
+ * lifecycle callbacks. Remove its manifest entry for a hard opt-out with no scanner startup or
+ * activity-tracking work.
  *
  * Configure the scanner from the app manifest with:
  * - `a11y_scanner_min_contrast`

--- a/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
@@ -3,7 +3,6 @@ package com.composea11yscanner
 import android.app.Activity
 import android.app.Application
 import android.content.Context
-import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -12,7 +11,7 @@ import com.composea11yscanner.core.model.ScannerConfig
 import com.composea11yscanner.rules.ScannerRules
 
 /**
- * AndroidX App Startup initializer for installing [ComposeA11yScanner] in debug builds.
+ * AndroidX App Startup initializer for installing [ComposeA11yScanner] in allowed builds.
  *
  * Configure the scanner from the app manifest with:
  * - `a11y_scanner_min_contrast`
@@ -38,16 +37,17 @@ class A11yScannerInitializer : Initializer<Unit> {
             object : Application.ActivityLifecycleCallbacks {
                 override fun onActivityResumed(activity: Activity) {
                     val componentActivity = activity as? ComponentActivity ?: return
-                    if (!componentActivity.isDebuggable() && !ComposeA11yScanner.allowInProd) return
                     componentActivity.window.decorView.post {
                         if (componentActivity.isDestroyed) return@post
-                        ComposeA11yScanner.install(componentActivity, config)
+                        ComposeA11yScanner.resume(componentActivity, config)
                     }
                 }
 
                 override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
                 override fun onActivityStarted(activity: Activity) = Unit
-                override fun onActivityPaused(activity: Activity) = Unit
+                override fun onActivityPaused(activity: Activity) {
+                    (activity as? ComponentActivity)?.let(ComposeA11yScanner::pause)
+                }
                 override fun onActivityStopped(activity: Activity) = Unit
                 override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
                 override fun onActivityDestroyed(activity: Activity) = Unit
@@ -61,9 +61,6 @@ class A11yScannerInitializer : Initializer<Unit> {
      * @return Empty list because the scanner has no initializer dependencies.
      */
     override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
-
-    private fun Context.isDebuggable(): Boolean =
-        applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
 
     private fun Context.readScannerConfig(): ScannerConfig {
         val metadata = applicationMetadata()

--- a/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
@@ -41,6 +41,7 @@ class A11yScannerInitializer : Initializer<Unit> {
             object : Application.ActivityLifecycleCallbacks {
                 override fun onActivityResumed(activity: Activity) {
                     val componentActivity = activity as? ComponentActivity ?: return
+                    ComposeA11yScanner.prepare(componentActivity)
                     componentActivity.window.decorView.post {
                         val resumed = canResume(
                             componentActivity.isDestroyed,
@@ -59,7 +60,7 @@ class A11yScannerInitializer : Initializer<Unit> {
                 override fun onActivityStopped(activity: Activity) = Unit
                 override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
                 override fun onActivityDestroyed(activity: Activity) {
-                    (activity as? ComponentActivity)?.let(ComposeA11yScanner::pause)
+                    (activity as? ComponentActivity)?.let(ComposeA11yScanner::destroy)
                 }
             },
         )

--- a/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
@@ -59,7 +59,7 @@ class A11yScannerInitializer : Initializer<Unit> {
                 override fun onActivityStopped(activity: Activity) = Unit
                 override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
                 override fun onActivityDestroyed(activity: Activity) {
-                    (activity as? ComponentActivity)?.let(ComposeA11yScanner::pause)
+                    (activity as? ComponentActivity)?.let(ComposeA11yScanner::destroy)
                 }
             },
         )

--- a/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/A11yScannerInitializer.kt
@@ -30,7 +30,6 @@ class A11yScannerInitializer : Initializer<Unit> {
         // Seed the context before the debug check so public API calls can distinguish a release
         // build from an early call made before the first activity controller is installed.
         ComposeA11yScanner.initialize(appContext)
-        if (!appContext.isDebuggable()) return
 
         val application = appContext as? Application ?: return
         val config = appContext.readScannerConfig()
@@ -39,6 +38,7 @@ class A11yScannerInitializer : Initializer<Unit> {
             object : Application.ActivityLifecycleCallbacks {
                 override fun onActivityResumed(activity: Activity) {
                     val componentActivity = activity as? ComponentActivity ?: return
+                    if (!componentActivity.isDebuggable() && !ComposeA11yScanner.allowInProd) return
                     componentActivity.window.decorView.post {
                         if (componentActivity.isDestroyed) return@post
                         ComposeA11yScanner.install(componentActivity, config)

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -96,6 +96,19 @@ object ComposeA11yScanner {
 
     /** Allows explicit scanner use in non-debuggable builds. */
     @Volatile var allowInProd = false
+        set(value) {
+            field = value
+            if (value) {
+                resumedActivity?.let { activity ->
+                    resumedConfig?.let { install(activity, it) }
+                }
+            } else if (cachedAppContext?.isDebuggable() == false) {
+                entries.keys.toList().forEach(::remove)
+            }
+        }
+
+    private var resumedActivity: ComponentActivity? = null
+    private var resumedConfig: ScannerConfig? = null
 
     /**
      * Controller for the most recently installed activity. Keeping this as state allows callers
@@ -186,6 +199,10 @@ object ComposeA11yScanner {
      */
     fun uninstall(activity: ComponentActivity) {
         requireDebugBuild(activity)
+        remove(activity)
+    }
+
+    private fun remove(activity: ComponentActivity) {
         entries.remove(activity)?.detach()
         activeController.value = entries.values.lastOrNull()?.controller
     }
@@ -231,9 +248,7 @@ object ComposeA11yScanner {
     // ── Debug guard ─────────────────────────────────────────────────────────────
 
     private fun requireDebugBuild(context: Context) {
-        if (!allowInProd &&
-            context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE == 0
-        ) {
+        if (!allowInProd && !context.isDebuggable()) {
             throw IllegalStateException(
                 "ComposeA11yScanner must only be used in debug builds. " +
                     "Remove all ComposeA11yScanner calls before shipping to production.",
@@ -245,6 +260,21 @@ object ComposeA11yScanner {
     internal fun initialize(context: Context) {
         cachedAppContext = context.applicationContext
     }
+
+    internal fun resume(activity: ComponentActivity, config: ScannerConfig) {
+        resumedActivity = activity
+        resumedConfig = config
+        if (activity.isDebuggable() || allowInProd) install(activity, config)
+    }
+
+    internal fun pause(activity: ComponentActivity) {
+        if (resumedActivity !== activity) return
+        resumedActivity = null
+        resumedConfig = null
+    }
+
+    private fun Context.isDebuggable(): Boolean =
+        applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
 
     // Overload for scan(), which has no Context parameter.
     private fun requireDebugBuild() {

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -206,7 +206,7 @@ object ComposeA11yScanner {
      */
     fun uninstall(activity: ComponentActivity) {
         requireDebugBuild(activity)
-        scannerLifecycle.uninstall(activity)
+        scannerLifecycle.pause(activity)
         remove(activity)
     }
 
@@ -284,11 +284,6 @@ object ComposeA11yScanner {
 
     internal fun pause(activity: ComponentActivity) {
         scannerLifecycle.pause(activity)
-        routeActive()
-    }
-
-    internal fun destroy(activity: ComponentActivity) {
-        scannerLifecycle.destroy(activity)
         routeActive()
     }
 

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -162,7 +162,6 @@ object ComposeA11yScanner {
         requireDebugBuild(activity)
         entries[activity]?.let { entry ->
             if (automatic) entry.automatic = true
-            activeController.value = entry.controller
             return
         }
 
@@ -264,6 +263,12 @@ object ComposeA11yScanner {
      */
     fun triggerScan(): Flow<ScannerState> {
         requireDebugBuild()
+        return activeController.value?.startScan() ?: emptyFlow()
+    }
+
+    internal fun triggerIfEnabled(): Flow<ScannerState> {
+        val context = cachedAppContext ?: return emptyFlow()
+        if (!scannerLifecycle.isAllowed(context.isDebuggable())) return emptyFlow()
         return activeController.value?.startScan() ?: emptyFlow()
     }
 

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -311,6 +311,26 @@ object ComposeA11yScanner {
         routeActive()
     }
 
+    internal fun resetForTests() {
+        entries.keys.toList().forEach(::remove)
+        scannerLifecycle.reset()
+        cachedAppContext = null
+        activeController.value = null
+    }
+
+    internal fun installedActivitiesForTests(): List<ComponentActivity> = entries.keys.toList()
+
+    internal fun activeActivityForTests(): ComponentActivity? {
+        val active = activeEntry() ?: return null
+        return entries.entries.lastOrNull { it.value === active }?.key
+    }
+
+    internal fun controllerForTests(activity: ComponentActivity): A11yScannerController? =
+        entries[activity]?.controller
+
+    internal fun overlayForTests(activity: ComponentActivity): ComposeView? =
+        entries[activity]?.overlayView
+
     private fun checkMainThread() {
         check(Looper.myLooper() == Looper.getMainLooper()) {
             "ComposeA11yScanner.toggleScanner() must be called on the main thread."

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -63,7 +63,7 @@ import kotlinx.coroutines.flow.flatMapLatest
  * only needed if the scanner should stop before destroy.
  *
  * **All three methods throw [IllegalStateException] in non-debug builds** (i.e., when
- * [ApplicationInfo.FLAG_DEBUGGABLE] is absent from the running APK), unless [allowInProd] is
+ * [ApplicationInfo.FLAG_DEBUGGABLE] is absent from the running APK), unless [toggleScanner] is
  * explicitly enabled. This is the correct runtime check for library code; `BuildConfig.DEBUG`
  * in a library module does not reflect the consuming app's build type.
  *
@@ -94,18 +94,20 @@ object ComposeA11yScanner {
     /** Set during [install] so that [scan] can perform the debug-build check without a [Context]. */
     @Volatile private var cachedAppContext: Context? = null
 
+    @Volatile private var prodAllowed = false
+
     /** Allows explicit scanner use in non-debuggable builds. */
-    @Volatile var allowInProd = false
-        set(value) {
-            field = value
-            if (value) {
-                resumedActivity?.let { activity ->
-                    resumedConfig?.let { install(activity, it) }
-                }
-            } else if (cachedAppContext?.isDebuggable() == false) {
-                entries.keys.toList().forEach(::remove)
+    fun toggleScanner(enabled: Boolean) {
+        if (prodAllowed == enabled) return
+        prodAllowed = enabled
+        if (enabled) {
+            resumedActivity?.let { activity ->
+                resumedConfig?.let { install(activity, it) }
             }
+        } else if (cachedAppContext?.isDebuggable() == false) {
+            entries.keys.toList().forEach(::remove)
         }
+    }
 
     private var resumedActivity: ComponentActivity? = null
     private var resumedConfig: ScannerConfig? = null
@@ -248,7 +250,7 @@ object ComposeA11yScanner {
     // ── Debug guard ─────────────────────────────────────────────────────────────
 
     private fun requireDebugBuild(context: Context) {
-        if (!allowInProd && !context.isDebuggable()) {
+        if (!prodAllowed && !context.isDebuggable()) {
             throw IllegalStateException(
                 "ComposeA11yScanner must only be used in debug builds. " +
                     "Remove all ComposeA11yScanner calls before shipping to production.",
@@ -264,7 +266,7 @@ object ComposeA11yScanner {
     internal fun resume(activity: ComponentActivity, config: ScannerConfig) {
         resumedActivity = activity
         resumedConfig = config
-        if (activity.isDebuggable() || allowInProd) install(activity, config)
+        if (activity.isDebuggable() || prodAllowed) install(activity, config)
     }
 
     internal fun pause(activity: ComponentActivity) {

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -99,7 +99,7 @@ object ComposeA11yScanner {
     private val scannerLifecycle = ScannerLifecycle<ComponentActivity, ScannerConfig>(
         checkMainThread = ::checkMainThread,
         isDebuggable = { it.isDebuggable() },
-        install = ::install,
+        install = ::installAuto,
         removeProd = {
             entries.keys.filterNot { it.isDebuggable() }.forEach(::remove)
         },
@@ -138,7 +138,7 @@ object ComposeA11yScanner {
     fun install(
         activity: ComponentActivity,
         config: ScannerConfig = ScannerConfig(enabledRules = ScannerRules.allRuleIds().toSet()),
-    ) = installInternal(activity, config, destinationKeyProvider = null)
+    ) = installInternal(activity, config, destinationKeyProvider = null, automatic = false)
 
     /**
      * Installs the scanner with an explicit key for single-host Compose navigation.
@@ -148,15 +148,23 @@ object ComposeA11yScanner {
         activity: ComponentActivity,
         destinationKeyProvider: () -> String?,
         config: ScannerConfig = ScannerConfig(enabledRules = ScannerRules.allRuleIds().toSet()),
-    ) = installInternal(activity, config, destinationKeyProvider)
+    ) = installInternal(activity, config, destinationKeyProvider, automatic = false)
+
+    private fun installAuto(activity: ComponentActivity, config: ScannerConfig) =
+        installInternal(activity, config, destinationKeyProvider = null, automatic = true)
 
     private fun installInternal(
         activity: ComponentActivity,
         config: ScannerConfig,
         destinationKeyProvider: (() -> String?)?,
+        automatic: Boolean,
     ) {
         requireDebugBuild(activity)
-        if (entries.containsKey(activity)) return
+        entries[activity]?.let { entry ->
+            if (automatic) entry.automatic = true
+            activeController.value = entry.controller
+            return
+        }
 
         cachedAppContext = activity.applicationContext
 
@@ -181,6 +189,7 @@ object ComposeA11yScanner {
         val entry = InstallEntry(
             controller = controller,
             overlayView = overlayView,
+            automatic = automatic,
             autoScan = config.autoScan,
             screenSnapshotProvider = {
                 activity.currentScreenSnapshot(destinationKeyProvider)
@@ -206,7 +215,7 @@ object ComposeA11yScanner {
      */
     fun uninstall(activity: ComponentActivity) {
         requireDebugBuild(activity)
-        scannerLifecycle.pause(activity)
+        scannerLifecycle.uninstall(activity)
         remove(activity)
     }
 
@@ -219,9 +228,11 @@ object ComposeA11yScanner {
         activeController.value = activeEntry()?.controller
     }
 
-    private fun activeEntry(): InstallEntry? = scannerLifecycle.resumedActivities()
-        .asReversed()
-        .firstNotNullOfOrNull(entries::get)
+    private fun activeEntry(): InstallEntry? = selectEntry(
+        resumedActivities = scannerLifecycle.resumedActivities(),
+        entries = entries,
+        isAutomatic = InstallEntry::automatic,
+    )
 
     /**
      * Returns a [Flow] of [ScannerState] for the most recently resumed installed activity.
@@ -277,6 +288,8 @@ object ComposeA11yScanner {
         cachedAppContext = context.applicationContext
     }
 
+    internal fun prepare(activity: ComponentActivity) = scannerLifecycle.prepare(activity)
+
     internal fun resume(activity: ComponentActivity, config: ScannerConfig) {
         scannerLifecycle.resume(activity, config)
         routeActive()
@@ -284,6 +297,11 @@ object ComposeA11yScanner {
 
     internal fun pause(activity: ComponentActivity) {
         scannerLifecycle.pause(activity)
+        routeActive()
+    }
+
+    internal fun destroy(activity: ComponentActivity) {
+        scannerLifecycle.destroy(activity)
         routeActive()
     }
 
@@ -510,6 +528,7 @@ object ComposeA11yScanner {
     private class InstallEntry(
         val controller: A11yScannerController,
         val overlayView: ComposeView,
+        var automatic: Boolean,
         private val autoScan: Boolean,
         private val screenSnapshotProvider: () -> ScreenSnapshot?,
         private val removeObserver: () -> Unit,

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -116,8 +116,8 @@ object ComposeA11yScanner {
     fun toggleScanner(enabled: Boolean) = scannerLifecycle.toggle(enabled)
 
     /**
-     * Controller for the most recently resumed installed activity. Keeping this as state allows
-     * callers to subscribe before automatic activity-resume installation has completed.
+     * Selected controller, preferring the latest resumed automatic activity and otherwise the
+     * latest surviving manual installation.
      */
     private val activeController = MutableStateFlow<A11yScannerController?>(null)
 
@@ -235,7 +235,8 @@ object ComposeA11yScanner {
     )
 
     /**
-     * Returns a [Flow] of [ScannerState] for the most recently resumed installed activity.
+     * Returns scanner state for the latest resumed automatic activity, or the latest surviving
+     * manual installation when automatic routing has no active entry.
      *
      * The backing [kotlinx.coroutines.flow.SharedFlow] has `replay = 1`, so late subscribers
      * immediately receive the current state. The returned flow can be collected before automatic
@@ -253,7 +254,7 @@ object ComposeA11yScanner {
     }
 
     /**
-     * Starts a scan for the most recently resumed installed activity and returns its state flow.
+     * Starts a scan for the selected automatic or manual installation and returns its state flow.
      *
      * This is useful for consumer-side triggers such as long press, shake, or debug menu actions.
      * Returns an empty flow when no scanner is installed.

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -63,9 +63,9 @@ import kotlinx.coroutines.flow.flatMapLatest
  * only needed if the scanner should stop before destroy.
  *
  * **All three methods throw [IllegalStateException] in non-debug builds** (i.e., when
- * [ApplicationInfo.FLAG_DEBUGGABLE] is absent from the running APK). This is the correct
- * runtime check for library code; `BuildConfig.DEBUG` in a library module does not reflect
- * the consuming app's build type.
+ * [ApplicationInfo.FLAG_DEBUGGABLE] is absent from the running APK), unless [allowInProd] is
+ * explicitly enabled. This is the correct runtime check for library code; `BuildConfig.DEBUG`
+ * in a library module does not reflect the consuming app's build type.
  *
  * Usage:
  * ```kotlin
@@ -93,6 +93,9 @@ object ComposeA11yScanner {
 
     /** Set during [install] so that [scan] can perform the debug-build check without a [Context]. */
     @Volatile private var cachedAppContext: Context? = null
+
+    /** Allows explicit scanner use in non-debuggable builds. */
+    @Volatile var allowInProd = false
 
     /**
      * Controller for the most recently installed activity. Keeping this as state allows callers
@@ -228,7 +231,9 @@ object ComposeA11yScanner {
     // ── Debug guard ─────────────────────────────────────────────────────────────
 
     private fun requireDebugBuild(context: Context) {
-        if (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE == 0) {
+        if (!allowInProd &&
+            context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE == 0
+        ) {
             throw IllegalStateException(
                 "ComposeA11yScanner must only be used in debug builds. " +
                     "Remove all ComposeA11yScanner calls before shipping to production.",

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -2,13 +2,14 @@ package com.composea11yscanner
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
-import android.graphics.Rect as AndroidRect
+import android.os.Looper
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.activity.ComponentActivity
+import androidx.annotation.MainThread
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -53,6 +54,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
+import android.graphics.Rect as AndroidRect
 
 /**
  * Top-level public API for the Compose Accessibility Scanner.
@@ -62,10 +64,10 @@ import kotlinx.coroutines.flow.flatMapLatest
  * removed automatically when the activity is destroyed, so explicit [uninstall] calls are
  * only needed if the scanner should stop before destroy.
  *
- * **All three methods throw [IllegalStateException] in non-debug builds** (i.e., when
- * [ApplicationInfo.FLAG_DEBUGGABLE] is absent from the running APK), unless [toggleScanner] is
- * explicitly enabled. This is the correct runtime check for library code; `BuildConfig.DEBUG`
- * in a library module does not reflect the consuming app's build type.
+ * Scanner calls throw [IllegalStateException] in non-debuggable builds unless [toggleScanner] is
+ * explicitly enabled on the main thread. Debuggable builds remain enabled regardless of the toggle.
+ * Checking [ApplicationInfo.FLAG_DEBUGGABLE] is correct for library code because a library module's
+ * `BuildConfig.DEBUG` does not reflect the consuming app's build type.
  *
  * Usage:
  * ```kotlin
@@ -94,23 +96,23 @@ object ComposeA11yScanner {
     /** Set during [install] so that [scan] can perform the debug-build check without a [Context]. */
     @Volatile private var cachedAppContext: Context? = null
 
-    @Volatile private var prodAllowed = false
+    private val scannerLifecycle = ScannerLifecycle<ComponentActivity, ScannerConfig>(
+        checkMainThread = ::checkMainThread,
+        isDebuggable = { it.isDebuggable() },
+        install = ::install,
+        removeProd = {
+            entries.keys.filterNot { it.isDebuggable() }.forEach(::remove)
+        },
+    )
 
-    /** Allows explicit scanner use in non-debuggable builds. */
-    fun toggleScanner(enabled: Boolean) {
-        if (prodAllowed == enabled) return
-        prodAllowed = enabled
-        if (enabled) {
-            resumedActivity?.let { activity ->
-                resumedConfig?.let { install(activity, it) }
-            }
-        } else if (cachedAppContext?.isDebuggable() == false) {
-            entries.keys.toList().forEach(::remove)
-        }
-    }
-
-    private var resumedActivity: ComponentActivity? = null
-    private var resumedConfig: ScannerConfig? = null
+    /**
+     * Enables or disables scanner installation in non-debuggable builds.
+     *
+     * Enabling installs the scanner on all resumed activities. Disabling removes non-debuggable
+     * overlays; debuggable builds remain enabled. This method must be called on the main thread.
+     */
+    @MainThread
+    fun toggleScanner(enabled: Boolean) = scannerLifecycle.toggle(enabled)
 
     /**
      * Controller for the most recently installed activity. Keeping this as state allows callers
@@ -130,7 +132,7 @@ object ComposeA11yScanner {
      *
      * @param activity Activity that should receive the scanner overlay.
      * @param config Scanner configuration applied to this install.
-     * @throws IllegalStateException in non-debug builds.
+     * @throws IllegalStateException in non-debuggable builds when the scanner is not enabled.
      */
     fun install(
         activity: ComponentActivity,
@@ -197,7 +199,7 @@ object ComposeA11yScanner {
      * Must be called on the main thread.
      *
      * @param activity Activity whose scanner overlay should be removed.
-     * @throws IllegalStateException in non-debug builds.
+     * @throws IllegalStateException in non-debuggable builds when the scanner is not enabled.
      */
     fun uninstall(activity: ComponentActivity) {
         requireDebugBuild(activity)
@@ -216,8 +218,8 @@ object ComposeA11yScanner {
      * immediately receive the current state. The returned flow can be collected before automatic
      * installation; it begins forwarding state when an activity scanner becomes available.
      *
-     * @throws IllegalStateException in non-debug builds, or when automatic initialization is
-     * disabled and this is called before [install].
+     * @throws IllegalStateException in a non-debuggable build when the scanner is not enabled, or
+     * when automatic initialization is disabled and this is called before [install].
      */
     @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     fun scan(): Flow<ScannerState> {
@@ -233,8 +235,8 @@ object ComposeA11yScanner {
      * This is useful for consumer-side triggers such as long press, shake, or debug menu actions.
      * Returns an empty flow when no scanner is installed.
      *
-     * @throws IllegalStateException in non-debug builds, or when automatic initialization is
-     * disabled and this is called before [install].
+     * @throws IllegalStateException in a non-debuggable build when the scanner is not enabled, or
+     * when automatic initialization is disabled and this is called before [install].
      */
     fun triggerScan(): Flow<ScannerState> {
         requireDebugBuild()
@@ -250,10 +252,10 @@ object ComposeA11yScanner {
     // ── Debug guard ─────────────────────────────────────────────────────────────
 
     private fun requireDebugBuild(context: Context) {
-        if (!prodAllowed && !context.isDebuggable()) {
+        if (!scannerLifecycle.isAllowed(context.isDebuggable())) {
             throw IllegalStateException(
-                "ComposeA11yScanner must only be used in debug builds. " +
-                    "Remove all ComposeA11yScanner calls before shipping to production.",
+                "ComposeA11yScanner requires a debuggable build or " +
+                    "toggleScanner(true) on the main thread.",
             )
         }
     }
@@ -263,16 +265,15 @@ object ComposeA11yScanner {
         cachedAppContext = context.applicationContext
     }
 
-    internal fun resume(activity: ComponentActivity, config: ScannerConfig) {
-        resumedActivity = activity
-        resumedConfig = config
-        if (activity.isDebuggable() || prodAllowed) install(activity, config)
-    }
+    internal fun resume(activity: ComponentActivity, config: ScannerConfig) =
+        scannerLifecycle.resume(activity, config)
 
-    internal fun pause(activity: ComponentActivity) {
-        if (resumedActivity !== activity) return
-        resumedActivity = null
-        resumedConfig = null
+    internal fun pause(activity: ComponentActivity) = scannerLifecycle.pause(activity)
+
+    private fun checkMainThread() {
+        check(Looper.myLooper() == Looper.getMainLooper()) {
+            "ComposeA11yScanner.toggleScanner() must be called on the main thread."
+        }
     }
 
     private fun Context.isDebuggable(): Boolean =
@@ -282,8 +283,8 @@ object ComposeA11yScanner {
     private fun requireDebugBuild() {
         val ctx = cachedAppContext
             ?: throw IllegalStateException(
-                "ComposeA11yScanner.scan() called before install(). " +
-                    "ComposeA11yScanner may only be used in debug builds.",
+                "ComposeA11yScanner called before install(). Enable production use with " +
+                    "toggleScanner(true) on the main thread.",
             )
         requireDebugBuild(ctx)
     }

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -108,15 +108,16 @@ object ComposeA11yScanner {
     /**
      * Enables or disables scanner installation in non-debuggable builds.
      *
-     * Enabling installs the scanner on all resumed activities. Disabling removes non-debuggable
+     * Enabling installs the scanner on eligible resumed activities. Explicitly uninstalled
+     * activities stay suppressed until their next resume. Disabling removes non-debuggable
      * overlays; debuggable builds remain enabled. This method must be called on the main thread.
      */
     @MainThread
     fun toggleScanner(enabled: Boolean) = scannerLifecycle.toggle(enabled)
 
     /**
-     * Controller for the most recently installed activity. Keeping this as state allows callers
-     * to subscribe before the automatic activity-resume installation has completed.
+     * Controller for the most recently resumed installed activity. Keeping this as state allows
+     * callers to subscribe before automatic activity-resume installation has completed.
      */
     private val activeController = MutableStateFlow<A11yScannerController?>(null)
 
@@ -176,6 +177,7 @@ object ComposeA11yScanner {
         }
         activity.addContentView(overlayView, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
 
+        val observer = AutoUninstallObserver(activity)
         val entry = InstallEntry(
             controller = controller,
             overlayView = overlayView,
@@ -183,18 +185,19 @@ object ComposeA11yScanner {
             screenSnapshotProvider = {
                 activity.currentScreenSnapshot(destinationKeyProvider)
             },
+            removeObserver = { activity.lifecycle.removeObserver(observer) },
         )
         entries[activity] = entry
         entry.attach()
         activeController.value = controller
-        activity.lifecycle.addObserver(AutoUninstallObserver(activity))
+        activity.lifecycle.addObserver(observer)
     }
 
     /**
      * Removes the scanner overlay from [activity] and cancels the internal coroutine scope.
      *
-     * This is called automatically when the activity is destroyed. Explicit calls are only
-     * needed to stop the scanner while the activity is still alive.
+     * This is called automatically when the activity is destroyed. Explicit calls stop the
+     * scanner while the activity remains alive and suppress reinstallation until its next resume.
      *
      * Must be called on the main thread.
      *
@@ -203,16 +206,25 @@ object ComposeA11yScanner {
      */
     fun uninstall(activity: ComponentActivity) {
         requireDebugBuild(activity)
+        scannerLifecycle.uninstall(activity)
         remove(activity)
     }
 
     private fun remove(activity: ComponentActivity) {
         entries.remove(activity)?.detach()
-        activeController.value = entries.values.lastOrNull()?.controller
+        routeActive()
     }
 
+    private fun routeActive() {
+        activeController.value = activeEntry()?.controller
+    }
+
+    private fun activeEntry(): InstallEntry? = scannerLifecycle.resumedActivities()
+        .asReversed()
+        .firstNotNullOfOrNull(entries::get)
+
     /**
-     * Returns a [Flow] of [ScannerState] for the most recently installed activity.
+     * Returns a [Flow] of [ScannerState] for the most recently resumed installed activity.
      *
      * The backing [kotlinx.coroutines.flow.SharedFlow] has `replay = 1`, so late subscribers
      * immediately receive the current state. The returned flow can be collected before automatic
@@ -230,7 +242,7 @@ object ComposeA11yScanner {
     }
 
     /**
-     * Starts a scan for the most recently installed activity and returns the shared state flow.
+     * Starts a scan for the most recently resumed installed activity and returns its state flow.
      *
      * This is useful for consumer-side triggers such as long press, shake, or debug menu actions.
      * Returns an empty flow when no scanner is installed.
@@ -240,13 +252,13 @@ object ComposeA11yScanner {
      */
     fun triggerScan(): Flow<ScannerState> {
         requireDebugBuild()
-        return entries.values.lastOrNull()?.controller?.startScan() ?: emptyFlow()
+        return activeController.value?.startScan() ?: emptyFlow()
     }
 
     /** Invalidates the current result and schedules a scan for the latest destination. */
     fun notifyScreenChanged() {
         requireDebugBuild()
-        entries.values.lastOrNull()?.notifyScreenChanged()
+        activeEntry()?.notifyScreenChanged()
     }
 
     // ── Debug guard ─────────────────────────────────────────────────────────────
@@ -265,10 +277,20 @@ object ComposeA11yScanner {
         cachedAppContext = context.applicationContext
     }
 
-    internal fun resume(activity: ComponentActivity, config: ScannerConfig) =
+    internal fun resume(activity: ComponentActivity, config: ScannerConfig) {
         scannerLifecycle.resume(activity, config)
+        routeActive()
+    }
 
-    internal fun pause(activity: ComponentActivity) = scannerLifecycle.pause(activity)
+    internal fun pause(activity: ComponentActivity) {
+        scannerLifecycle.pause(activity)
+        routeActive()
+    }
+
+    internal fun destroy(activity: ComponentActivity) {
+        scannerLifecycle.destroy(activity)
+        routeActive()
+    }
 
     private fun checkMainThread() {
         check(Looper.myLooper() == Looper.getMainLooper()) {
@@ -495,6 +517,7 @@ object ComposeA11yScanner {
         val overlayView: ComposeView,
         private val autoScan: Boolean,
         private val screenSnapshotProvider: () -> ScreenSnapshot?,
+        private val removeObserver: () -> Unit,
     ) : ViewTreeObserver.OnPreDrawListener {
         private var baselineFingerprint: ScreenFingerprint? = null
         private var completedScanId: String? = null
@@ -644,6 +667,7 @@ object ComposeA11yScanner {
         }
 
         fun detach() {
+            removeObserver()
             val observer = overlayView.rootView.viewTreeObserver
             if (observer.isAlive) observer.removeOnPreDrawListener(this)
             overlayView.removeCallbacks(initialScanRunnable)
@@ -704,8 +728,7 @@ object ComposeA11yScanner {
     ) : DefaultLifecycleObserver {
         override fun onDestroy(owner: LifecycleOwner) {
             // entries[activity] may already be null if uninstall() was called manually first.
-            entries.remove(activity)?.detach()
-            activeController.value = entries.values.lastOrNull()?.controller
+            remove(activity)
         }
     }
 }

--- a/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ComposeA11yScanner.kt
@@ -64,8 +64,9 @@ import android.graphics.Rect as AndroidRect
  * removed automatically when the activity is destroyed, so explicit [uninstall] calls are
  * only needed if the scanner should stop before destroy.
  *
- * Scanner calls throw [IllegalStateException] in non-debuggable builds unless [toggleScanner] is
- * explicitly enabled on the main thread. Debuggable builds remain enabled regardless of the toggle.
+ * Scanner calls are allowed by default in debuggable builds and denied by default in
+ * non-debuggable builds. [toggleScanner] explicitly overrides either default: `false` disables the
+ * scanner in every build, while `true` enables it in every build.
  * Checking [ApplicationInfo.FLAG_DEBUGGABLE] is correct for library code because a library module's
  * `BuildConfig.DEBUG` does not reflect the consuming app's build type.
  *
@@ -93,7 +94,7 @@ object ComposeA11yScanner {
      */
     private val entries = LinkedHashMap<ComponentActivity, InstallEntry>()
 
-    /** Set during [install] so that [scan] can perform the debug-build check without a [Context]. */
+    /** Set during [install] so that [scan] can perform the permission check without a [Context]. */
     @Volatile private var cachedAppContext: Context? = null
 
     private val scannerLifecycle = ScannerLifecycle<ComponentActivity, ScannerConfig>(
@@ -101,16 +102,20 @@ object ComposeA11yScanner {
         isDebuggable = { it.isDebuggable() },
         install = ::installAuto,
         removeProd = {
-            entries.keys.filterNot { it.isDebuggable() }.forEach(::remove)
+            entries.keys.toList().forEach(::remove)
         },
     )
 
     /**
-     * Enables or disables scanner installation in non-debuggable builds.
+     * Overrides the default scanner availability for every build.
      *
+     * Before the first call, debuggable builds are enabled and non-debuggable builds are denied.
      * Enabling installs the scanner on eligible resumed activities. Explicitly uninstalled
-     * activities stay suppressed until their next resume. Disabling removes non-debuggable
-     * overlays; debuggable builds remain enabled. This method must be called on the main thread.
+     * activities stay suppressed until their next resume. Disabling removes every scanner overlay
+     * and prevents reinstallation until enabled again. AndroidX Startup callbacks remain registered
+     * so resumed activities can be tracked for immediate re-enabling; remove the initializer from
+     * the app manifest when no scanner startup or lifecycle work is allowed. This method must be
+     * called on the main thread.
      */
     @MainThread
     fun toggleScanner(enabled: Boolean) = scannerLifecycle.toggle(enabled)
@@ -133,7 +138,7 @@ object ComposeA11yScanner {
      *
      * @param activity Activity that should receive the scanner overlay.
      * @param config Scanner configuration applied to this install.
-     * @throws IllegalStateException in non-debuggable builds when the scanner is not enabled.
+     * @throws IllegalStateException when the scanner is denied by the current build/toggle policy.
      */
     fun install(
         activity: ComponentActivity,
@@ -209,11 +214,12 @@ object ComposeA11yScanner {
      *
      * Must be called on the main thread.
      *
+     * This remains safe and idempotent after [toggleScanner] disables the scanner.
+     *
      * @param activity Activity whose scanner overlay should be removed.
-     * @throws IllegalStateException in non-debuggable builds when the scanner is not enabled.
      */
     fun uninstall(activity: ComponentActivity) {
-        requireDebugBuild(activity)
+        checkMainThread()
         scannerLifecycle.uninstall(activity)
         remove(activity)
     }
@@ -241,8 +247,8 @@ object ComposeA11yScanner {
      * immediately receive the current state. The returned flow can be collected before automatic
      * installation; it begins forwarding state when an activity scanner becomes available.
      *
-     * @throws IllegalStateException in a non-debuggable build when the scanner is not enabled, or
-     * when automatic initialization is disabled and this is called before [install].
+     * @throws IllegalStateException when the scanner is denied by the current build/toggle policy,
+     * or when automatic initialization is disabled and this is called before [install].
      */
     @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     fun scan(): Flow<ScannerState> {
@@ -258,8 +264,8 @@ object ComposeA11yScanner {
      * This is useful for consumer-side triggers such as long press, shake, or debug menu actions.
      * Returns an empty flow when no scanner is installed.
      *
-     * @throws IllegalStateException in a non-debuggable build when the scanner is not enabled, or
-     * when automatic initialization is disabled and this is called before [install].
+     * @throws IllegalStateException when the scanner is denied by the current build/toggle policy,
+     * or when automatic initialization is disabled and this is called before [install].
      */
     fun triggerScan(): Flow<ScannerState> {
         requireDebugBuild()
@@ -283,8 +289,8 @@ object ComposeA11yScanner {
     private fun requireDebugBuild(context: Context) {
         if (!scannerLifecycle.isAllowed(context.isDebuggable())) {
             throw IllegalStateException(
-                "ComposeA11yScanner requires a debuggable build or " +
-                    "toggleScanner(true) on the main thread.",
+                "ComposeA11yScanner is disabled by the current build/toggle policy. " +
+                    "Call toggleScanner(true) on the main thread to enable it.",
             )
         }
     }

--- a/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
@@ -1,0 +1,32 @@
+package com.composea11yscanner
+
+internal class ScannerLifecycle<Activity, Config>(
+    private val checkMainThread: () -> Unit,
+    private val isDebuggable: (Activity) -> Boolean,
+    private val install: (Activity, Config) -> Unit,
+    private val removeProd: () -> Unit,
+) {
+    private val resumed = LinkedHashMap<Activity, Config>()
+
+    @Volatile private var prodAllowed = false
+
+    fun toggle(enabled: Boolean) {
+        checkMainThread()
+        if (prodAllowed == enabled) return
+        prodAllowed = enabled
+        if (enabled) resumed.forEach(install) else removeProd()
+    }
+
+    fun resume(activity: Activity, config: Config) {
+        checkMainThread()
+        resumed[activity] = config
+        if (isDebuggable(activity) || prodAllowed) install(activity, config)
+    }
+
+    fun pause(activity: Activity) {
+        checkMainThread()
+        resumed.remove(activity)
+    }
+
+    fun isAllowed(debuggable: Boolean) = debuggable || prodAllowed
+}

--- a/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
@@ -7,6 +7,8 @@ internal class ScannerLifecycle<Activity, Config>(
     private val removeProd: () -> Unit,
 ) {
     private val resumed = LinkedHashMap<Activity, Config>()
+    private val pending = mutableSetOf<Activity>()
+    private val suppressed = mutableSetOf<Activity>()
 
     @Volatile private var prodAllowed = false
 
@@ -17,8 +19,15 @@ internal class ScannerLifecycle<Activity, Config>(
         if (enabled) resumed.forEach(install) else removeProd()
     }
 
+    fun prepare(activity: Activity) {
+        checkMainThread()
+        pending += activity
+    }
+
     fun resume(activity: Activity, config: Config) {
         checkMainThread()
+        pending.remove(activity)
+        if (activity in suppressed) return
         resumed.remove(activity)
         resumed[activity] = config
         if (isDebuggable(activity) || prodAllowed) install(activity, config)
@@ -26,10 +35,35 @@ internal class ScannerLifecycle<Activity, Config>(
 
     fun pause(activity: Activity) {
         checkMainThread()
+        pending.remove(activity)
         resumed.remove(activity)
+        suppressed.remove(activity)
+    }
+
+    fun uninstall(activity: Activity) {
+        checkMainThread()
+        val tracked = activity in pending || activity in resumed
+        resumed.remove(activity)
+        if (tracked) suppressed += activity
+    }
+
+    fun destroy(activity: Activity) {
+        checkMainThread()
+        pending.remove(activity)
+        resumed.remove(activity)
+        suppressed.remove(activity)
     }
 
     fun resumedActivities(): List<Activity> = resumed.keys.toList()
 
     fun isAllowed(debuggable: Boolean) = debuggable || prodAllowed
 }
+
+internal fun <Activity, Entry> selectEntry(
+    resumedActivities: List<Activity>,
+    entries: Map<Activity, Entry>,
+    isAutomatic: (Entry) -> Boolean,
+): Entry? = resumedActivities
+    .asReversed()
+    .firstNotNullOfOrNull { entries[it]?.takeIf(isAutomatic) }
+    ?: entries.values.lastOrNull { !isAutomatic(it) }

--- a/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
@@ -10,7 +10,7 @@ internal class ScannerLifecycle<Activity, Config>(
     private val pending = mutableSetOf<Activity>()
     private val suppressed = mutableSetOf<Activity>()
 
-    @Volatile private var prodAllowed = false
+    @Volatile private var prodAllowed: Boolean? = null
 
     fun toggle(enabled: Boolean) {
         checkMainThread()
@@ -30,7 +30,7 @@ internal class ScannerLifecycle<Activity, Config>(
         if (activity in suppressed) return
         resumed.remove(activity)
         resumed[activity] = config
-        if (isDebuggable(activity) || prodAllowed) install(activity, config)
+        if (prodAllowed ?: isDebuggable(activity)) install(activity, config)
     }
 
     fun pause(activity: Activity) {
@@ -56,13 +56,13 @@ internal class ScannerLifecycle<Activity, Config>(
 
     fun resumedActivities(): List<Activity> = resumed.keys.toList()
 
-    fun isAllowed(debuggable: Boolean) = debuggable || prodAllowed
+    fun isAllowed(debuggable: Boolean) = prodAllowed ?: debuggable
 
     fun reset() {
         resumed.clear()
         pending.clear()
         suppressed.clear()
-        prodAllowed = false
+        prodAllowed = null
     }
 }
 

--- a/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
@@ -7,6 +7,7 @@ internal class ScannerLifecycle<Activity, Config>(
     private val removeProd: () -> Unit,
 ) {
     private val resumed = LinkedHashMap<Activity, Config>()
+    private val suppressed = mutableSetOf<Activity>()
 
     @Volatile private var prodAllowed = false
 
@@ -14,12 +15,18 @@ internal class ScannerLifecycle<Activity, Config>(
         checkMainThread()
         if (prodAllowed == enabled) return
         prodAllowed = enabled
-        if (enabled) resumed.forEach(install) else removeProd()
+        if (enabled) {
+            resumed.filterKeys { it !in suppressed }.forEach(install)
+        } else {
+            removeProd()
+        }
     }
 
     fun resume(activity: Activity, config: Config) {
         checkMainThread()
+        resumed.remove(activity)
         resumed[activity] = config
+        suppressed.remove(activity)
         if (isDebuggable(activity) || prodAllowed) install(activity, config)
     }
 
@@ -27,6 +34,19 @@ internal class ScannerLifecycle<Activity, Config>(
         checkMainThread()
         resumed.remove(activity)
     }
+
+    fun uninstall(activity: Activity) {
+        checkMainThread()
+        suppressed += activity
+    }
+
+    fun destroy(activity: Activity) {
+        checkMainThread()
+        resumed.remove(activity)
+        suppressed.remove(activity)
+    }
+
+    fun resumedActivities(): List<Activity> = resumed.keys.filterNot(suppressed::contains)
 
     fun isAllowed(debuggable: Boolean) = debuggable || prodAllowed
 }

--- a/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
@@ -57,6 +57,13 @@ internal class ScannerLifecycle<Activity, Config>(
     fun resumedActivities(): List<Activity> = resumed.keys.toList()
 
     fun isAllowed(debuggable: Boolean) = debuggable || prodAllowed
+
+    fun reset() {
+        resumed.clear()
+        pending.clear()
+        suppressed.clear()
+        prodAllowed = false
+    }
 }
 
 internal fun <Activity, Entry> selectEntry(

--- a/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/ScannerLifecycle.kt
@@ -7,7 +7,6 @@ internal class ScannerLifecycle<Activity, Config>(
     private val removeProd: () -> Unit,
 ) {
     private val resumed = LinkedHashMap<Activity, Config>()
-    private val suppressed = mutableSetOf<Activity>()
 
     @Volatile private var prodAllowed = false
 
@@ -15,18 +14,13 @@ internal class ScannerLifecycle<Activity, Config>(
         checkMainThread()
         if (prodAllowed == enabled) return
         prodAllowed = enabled
-        if (enabled) {
-            resumed.filterKeys { it !in suppressed }.forEach(install)
-        } else {
-            removeProd()
-        }
+        if (enabled) resumed.forEach(install) else removeProd()
     }
 
     fun resume(activity: Activity, config: Config) {
         checkMainThread()
         resumed.remove(activity)
         resumed[activity] = config
-        suppressed.remove(activity)
         if (isDebuggable(activity) || prodAllowed) install(activity, config)
     }
 
@@ -35,18 +29,7 @@ internal class ScannerLifecycle<Activity, Config>(
         resumed.remove(activity)
     }
 
-    fun uninstall(activity: Activity) {
-        checkMainThread()
-        suppressed += activity
-    }
-
-    fun destroy(activity: Activity) {
-        checkMainThread()
-        resumed.remove(activity)
-        suppressed.remove(activity)
-    }
-
-    fun resumedActivities(): List<Activity> = resumed.keys.filterNot(suppressed::contains)
+    fun resumedActivities(): List<Activity> = resumed.keys.toList()
 
     fun isAllowed(debuggable: Boolean) = debuggable || prodAllowed
 }

--- a/scanner-ui/src/main/java/com/composea11yscanner/triggers/ScanTriggerExtensions.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/triggers/ScanTriggerExtensions.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import com.composea11yscanner.ComposeA11yScanner
 
+private val defaultScanRequest: () -> Unit = { ComposeA11yScanner.triggerIfEnabled() }
+
 /**
  * Starts a ComposeA11yScanner scan when this element is long-pressed.
  *
@@ -27,7 +29,7 @@ import com.composea11yscanner.ComposeA11yScanner
  */
 fun Modifier.scanOnLongPress(
     enabled: Boolean = true,
-    onScanRequested: () -> Unit = { ComposeA11yScanner.triggerIfEnabled() },
+    onScanRequested: () -> Unit = defaultScanRequest,
 ): Modifier {
     if (!enabled) return this
     return pointerInput(onScanRequested) {
@@ -51,7 +53,7 @@ fun scanOnShake(
     enabled: Boolean = true,
     shakeThresholdG: Float = 2.7f,
     minTriggerIntervalMillis: Long = 1_500L,
-    onScanRequested: () -> Unit = { ComposeA11yScanner.triggerIfEnabled() },
+    onScanRequested: () -> Unit = defaultScanRequest,
 ) {
     val context = LocalContext.current
     val currentOnScanRequested = rememberUpdatedState(onScanRequested)

--- a/scanner-ui/src/main/java/com/composea11yscanner/triggers/ScanTriggerExtensions.kt
+++ b/scanner-ui/src/main/java/com/composea11yscanner/triggers/ScanTriggerExtensions.kt
@@ -18,8 +18,8 @@ import com.composea11yscanner.ComposeA11yScanner
 /**
  * Starts a ComposeA11yScanner scan when this element is long-pressed.
  *
- * Kept as a consumer-side convenience extension in `:scanner-ui`; scanner core has no
- * dependency on gestures, sensors, Android framework callbacks, or Compose modifiers.
+ * The default callback quietly does nothing when the scanner is disabled or not installed.
+ * Scanner core has no dependency on gestures, sensors, framework callbacks, or Compose modifiers.
  *
  * @param enabled Whether long-press scanning is active.
  * @param onScanRequested Callback invoked after a long press.
@@ -27,7 +27,7 @@ import com.composea11yscanner.ComposeA11yScanner
  */
 fun Modifier.scanOnLongPress(
     enabled: Boolean = true,
-    onScanRequested: () -> Unit = { ComposeA11yScanner.triggerScan() },
+    onScanRequested: () -> Unit = { ComposeA11yScanner.triggerIfEnabled() },
 ): Modifier {
     if (!enabled) return this
     return pointerInput(onScanRequested) {
@@ -38,8 +38,8 @@ fun Modifier.scanOnLongPress(
 /**
  * Starts a ComposeA11yScanner scan when the device is shaken.
  *
- * Call from a composable screen that wants shake-triggered scans. If no accelerometer is
- * present, this quietly does nothing.
+ * Call from a composable screen that wants shake-triggered scans. If no accelerometer is present,
+ * or the scanner is disabled or not installed, the default callback quietly does nothing.
  *
  * @param enabled Whether shake scanning is active.
  * @param shakeThresholdG Required acceleration force in Gs.
@@ -51,7 +51,7 @@ fun scanOnShake(
     enabled: Boolean = true,
     shakeThresholdG: Float = 2.7f,
     minTriggerIntervalMillis: Long = 1_500L,
-    onScanRequested: () -> Unit = { ComposeA11yScanner.triggerScan() },
+    onScanRequested: () -> Unit = { ComposeA11yScanner.triggerIfEnabled() },
 ) {
     val context = LocalContext.current
     val currentOnScanRequested = rememberUpdatedState(onScanRequested)

--- a/scanner-ui/src/test/java/com/composea11yscanner/ComposeA11yScannerIntegrationTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ComposeA11yScannerIntegrationTest.kt
@@ -1,0 +1,152 @@
+package com.composea11yscanner
+
+import android.content.Context
+import android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE
+import android.os.Looper
+import androidx.activity.ComponentActivity
+import androidx.test.core.app.ApplicationProvider
+import com.composea11yscanner.core.model.ScannerConfig
+import com.composea11yscanner.core.model.ScannerState
+import java.time.Duration
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@LooperMode(LooperMode.Mode.PAUSED)
+class ComposeA11yScannerIntegrationTest {
+    private val config = ScannerConfig(enabledRules = emptySet(), autoScan = false)
+
+    @Before
+    fun setUp() {
+        val appContext = ApplicationProvider.getApplicationContext<Context>()
+        appContext.applicationInfo.flags = appContext.applicationInfo.flags or FLAG_DEBUGGABLE
+        ComposeA11yScanner.resetForTests()
+    }
+
+    @After
+    fun tearDown() {
+        ComposeA11yScanner.resetForTests()
+    }
+
+    @Test
+    fun `queued resume cannot recreate explicitly uninstalled overlay`() {
+        val activity = activity()
+        ComposeA11yScanner.prepare(activity)
+        activity.window.decorView.post { ComposeA11yScanner.resume(activity, config) }
+
+        ComposeA11yScanner.uninstall(activity)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertFalse(activity in ComposeA11yScanner.installedActivitiesForTests())
+        assertNull(ComposeA11yScanner.overlayForTests(activity))
+
+        ComposeA11yScanner.pause(activity)
+        ComposeA11yScanner.resume(activity, config)
+
+        assertTrue(activity in ComposeA11yScanner.installedActivitiesForTests())
+        assertTrue(ComposeA11yScanner.overlayForTests(activity)?.parent != null)
+    }
+
+    @Test
+    fun `repeated manual installation remains single and detach removes overlay`() {
+        val activity = activity()
+
+        ComposeA11yScanner.install(activity, config)
+        val overlay = ComposeA11yScanner.overlayForTests(activity)
+        val controller = ComposeA11yScanner.controllerForTests(activity)
+        ComposeA11yScanner.install(activity, config)
+
+        assertEquals(listOf(activity), ComposeA11yScanner.installedActivitiesForTests())
+        assertSame(overlay, ComposeA11yScanner.overlayForTests(activity))
+        assertSame(controller, ComposeA11yScanner.controllerForTests(activity))
+
+        ComposeA11yScanner.uninstall(activity)
+
+        assertNull(overlay?.parent)
+        assertNull(ComposeA11yScanner.controllerForTests(activity))
+        assertNull(ComposeA11yScanner.activeActivityForTests())
+    }
+
+    @Test
+    fun `detach cancels queued initial and rescan callbacks`() {
+        val activity = activity()
+        val autoConfig = config.copy(autoScan = true)
+
+        ComposeA11yScanner.install(activity, autoConfig)
+        val overlay = ComposeA11yScanner.overlayForTests(activity)
+        val controller = ComposeA11yScanner.controllerForTests(activity)
+        ComposeA11yScanner.notifyScreenChanged()
+        ComposeA11yScanner.uninstall(activity)
+
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(3))
+
+        assertNull(overlay?.parent)
+        assertTrue(controller?.currentState is ScannerState.Idle)
+        assertNull(ComposeA11yScanner.controllerForTests(activity))
+    }
+
+    @Test
+    fun `manual routing resumes after automatic activity pauses`() {
+        val manual = activity()
+        val automatic = activity()
+        ComposeA11yScanner.resetForTests()
+
+        ComposeA11yScanner.install(manual, config)
+        ComposeA11yScanner.resume(automatic, config)
+
+        assertSame(automatic, ComposeA11yScanner.activeActivityForTests())
+        ComposeA11yScanner.install(manual, config)
+        assertSame(automatic, ComposeA11yScanner.activeActivityForTests())
+        ComposeA11yScanner.triggerScan()
+        assertTrue(ComposeA11yScanner.controllerForTests(automatic)?.currentState is ScannerState.Scanning)
+        ComposeA11yScanner.notifyScreenChanged()
+        assertTrue(ComposeA11yScanner.controllerForTests(automatic)?.currentState is ScannerState.Idle)
+
+        ComposeA11yScanner.pause(automatic)
+
+        assertSame(manual, ComposeA11yScanner.activeActivityForTests())
+        ComposeA11yScanner.triggerScan()
+        assertTrue(ComposeA11yScanner.controllerForTests(manual)?.currentState is ScannerState.Scanning)
+        ComposeA11yScanner.notifyScreenChanged()
+        assertTrue(ComposeA11yScanner.controllerForTests(manual)?.currentState is ScannerState.Idle)
+    }
+
+    @Test
+    fun `trusted triggers quietly no-op before installation and after disable`() = runBlocking {
+        val activity = activity()
+        ComposeA11yScanner.resetForTests()
+        activity.applicationInfo.flags = activity.applicationInfo.flags and FLAG_DEBUGGABLE.inv()
+        ComposeA11yScanner.initialize(activity.applicationContext)
+
+        assertNull(ComposeA11yScanner.triggerIfEnabled().firstOrNull())
+
+        ComposeA11yScanner.toggleScanner(true)
+        ComposeA11yScanner.resume(activity, config)
+        assertTrue(activity in ComposeA11yScanner.installedActivitiesForTests())
+
+        ComposeA11yScanner.toggleScanner(false)
+
+        assertFalse(activity in ComposeA11yScanner.installedActivitiesForTests())
+        assertNull(ComposeA11yScanner.triggerIfEnabled().firstOrNull())
+    }
+
+    private fun activity(): TestActivity =
+        Robolectric.buildActivity(TestActivity::class.java).create().start().get()
+
+    class TestActivity : ComponentActivity()
+}

--- a/scanner-ui/src/test/java/com/composea11yscanner/ComposeA11yScannerIntegrationTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ComposeA11yScannerIntegrationTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -124,6 +125,41 @@ class ComposeA11yScannerIntegrationTest {
         assertTrue(ComposeA11yScanner.controllerForTests(manual)?.currentState is ScannerState.Scanning)
         ComposeA11yScanner.notifyScreenChanged()
         assertTrue(ComposeA11yScanner.controllerForTests(manual)?.currentState is ScannerState.Idle)
+    }
+
+    @Test
+    fun `explicit disable blocks and removes debug installations`() = runBlocking {
+        val activity = activity()
+
+        ComposeA11yScanner.toggleScanner(false)
+        ComposeA11yScanner.resume(activity, config)
+
+        assertFalse(activity in ComposeA11yScanner.installedActivitiesForTests())
+        assertThrows(IllegalStateException::class.java) {
+            ComposeA11yScanner.install(activity, config)
+        }
+        assertNull(ComposeA11yScanner.triggerIfEnabled().firstOrNull())
+
+        ComposeA11yScanner.toggleScanner(true)
+
+        assertTrue(activity in ComposeA11yScanner.installedActivitiesForTests())
+        val overlay = ComposeA11yScanner.overlayForTests(activity)
+        assertTrue(overlay?.parent != null)
+
+        ComposeA11yScanner.toggleScanner(false)
+
+        assertFalse(activity in ComposeA11yScanner.installedActivitiesForTests())
+        assertNull(overlay?.parent)
+        assertNull(ComposeA11yScanner.activeActivityForTests())
+        assertThrows(IllegalStateException::class.java) { ComposeA11yScanner.scan() }
+        assertThrows(IllegalStateException::class.java) { ComposeA11yScanner.triggerScan() }
+        assertThrows(IllegalStateException::class.java) { ComposeA11yScanner.notifyScreenChanged() }
+        assertNull(ComposeA11yScanner.triggerIfEnabled().firstOrNull())
+
+        ComposeA11yScanner.uninstall(activity)
+        ComposeA11yScanner.toggleScanner(true)
+
+        assertFalse(activity in ComposeA11yScanner.installedActivitiesForTests())
     }
 
     @Test

--- a/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
@@ -74,7 +74,27 @@ class ScannerLifecycleTest {
     }
 
     @Test
-    fun `disable removes only production installs and is idempotent`() {
+    fun `explicit disable blocks debug activities until reenabled`() {
+        val installed = mutableListOf<String>()
+        val lifecycle = lifecycle(
+            debugActivities = setOf("debug"),
+            installed = installed,
+        )
+
+        lifecycle.toggle(false)
+        lifecycle.resume("debug", Unit)
+
+        assertTrue(installed.isEmpty())
+        assertFalse(lifecycle.isAllowed(debuggable = true))
+
+        lifecycle.toggle(true)
+
+        assertEquals(listOf("debug"), installed)
+        assertTrue(lifecycle.isAllowed(debuggable = true))
+    }
+
+    @Test
+    fun `disable removes all installs and is idempotent`() {
         val installed = mutableListOf<String>()
         var removals = 0
         val lifecycle = lifecycle(
@@ -82,7 +102,7 @@ class ScannerLifecycleTest {
             installed = installed,
             removeProd = {
                 removals++
-                installed.removeAll { it != "debug" }
+                installed.clear()
             },
         )
         lifecycle.resume("debug", Unit)
@@ -93,7 +113,8 @@ class ScannerLifecycleTest {
         lifecycle.toggle(false)
 
         assertEquals(1, removals)
-        assertEquals(listOf("debug", "debug"), installed)
+        assertTrue(installed.isEmpty())
+        assertFalse(lifecycle.isAllowed(debuggable = true))
         assertFalse(lifecycle.isAllowed(debuggable = false))
     }
 
@@ -122,7 +143,7 @@ class ScannerLifecycleTest {
         debugActivities: Set<String> = emptySet(),
         installed: MutableList<String> = mutableListOf(),
         removeProd: () -> Unit = {
-            installed.removeAll { it !in debugActivities }
+            installed.clear()
         },
     ) = ScannerLifecycle<String, Unit>(
         checkMainThread = checkMainThread,

--- a/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
@@ -1,0 +1,131 @@
+package com.composea11yscanner
+
+import androidx.lifecycle.Lifecycle.State.CREATED
+import androidx.lifecycle.Lifecycle.State.DESTROYED
+import androidx.lifecycle.Lifecycle.State.RESUMED
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScannerLifecycleTest {
+
+    @Test
+    fun `production is denied by default`() {
+        val lifecycle = lifecycle()
+
+        assertFalse(lifecycle.isAllowed(debuggable = false))
+        assertTrue(lifecycle.isAllowed(debuggable = true))
+    }
+
+    @Test
+    fun `enable before resume installs on resume`() {
+        val installed = mutableListOf<String>()
+        val lifecycle = lifecycle(installed = installed)
+
+        lifecycle.toggle(true)
+        lifecycle.resume("first", Unit)
+
+        assertEquals(listOf("first"), installed)
+    }
+
+    @Test
+    fun `enable after resume installs every resumed activity`() {
+        val installed = mutableListOf<String>()
+        val lifecycle = lifecycle(installed = installed)
+        lifecycle.resume("first", Unit)
+        lifecycle.resume("second", Unit)
+
+        lifecycle.toggle(true)
+
+        assertEquals(listOf("first", "second"), installed)
+    }
+
+    @Test
+    fun `paused activity is not reinstalled`() {
+        val installed = mutableListOf<String>()
+        val lifecycle = lifecycle(installed = installed)
+        lifecycle.resume("first", Unit)
+        lifecycle.resume("second", Unit)
+        lifecycle.pause("first")
+
+        lifecycle.toggle(true)
+
+        assertEquals(listOf("second"), installed)
+    }
+
+    @Test
+    fun `disable removes production installs`() {
+        val installed = mutableListOf<String>()
+        val lifecycle = lifecycle(installed = installed)
+        lifecycle.toggle(true)
+        lifecycle.resume("first", Unit)
+
+        lifecycle.toggle(false)
+
+        assertTrue(installed.isEmpty())
+        assertFalse(lifecycle.isAllowed(debuggable = false))
+    }
+
+    @Test
+    fun `debug activity remains installed when production is disabled`() {
+        val installed = mutableListOf<String>()
+        val lifecycle = lifecycle(
+            debugActivities = setOf("debug"),
+            installed = installed,
+        )
+        lifecycle.resume("debug", Unit)
+        lifecycle.toggle(true)
+        lifecycle.toggle(false)
+
+        assertEquals(listOf("debug", "debug"), installed)
+    }
+
+    @Test
+    fun `repeated toggle is idempotent`() {
+        var removals = 0
+        val lifecycle = lifecycle(removeProd = { removals++ })
+
+        lifecycle.toggle(true)
+        lifecycle.toggle(true)
+        lifecycle.toggle(false)
+        lifecycle.toggle(false)
+
+        assertEquals(1, removals)
+    }
+
+    @Test
+    fun `worker thread rejection happens before state change`() {
+        var mainThread = false
+        val lifecycle = lifecycle(checkMainThread = { check(mainThread) })
+
+        assertThrows(IllegalStateException::class.java) {
+            lifecycle.toggle(true)
+        }
+
+        assertFalse(lifecycle.isAllowed(debuggable = false))
+    }
+
+    @Test
+    fun `deferred resume requires a resumed live activity`() {
+        assertTrue(canResume(destroyed = false, state = RESUMED))
+        assertFalse(canResume(destroyed = false, state = CREATED))
+        assertFalse(canResume(destroyed = true, state = RESUMED))
+        assertFalse(canResume(destroyed = true, state = DESTROYED))
+    }
+
+    private fun lifecycle(
+        checkMainThread: () -> Unit = {},
+        debugActivities: Set<String> = emptySet(),
+        installed: MutableList<String> = mutableListOf(),
+        removeProd: () -> Unit = {
+            installed.removeAll { it !in debugActivities }
+        },
+    ) = ScannerLifecycle<String, Unit>(
+        checkMainThread = checkMainThread,
+        isDebuggable = debugActivities::contains,
+        install = { activity, _ -> installed += activity },
+        removeProd = removeProd,
+    )
+}

--- a/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
@@ -67,21 +67,68 @@ class ScannerLifecycleTest {
     }
 
     @Test
-    fun `removed activity is ignored until next resume`() {
+    fun `queued resume cannot reverse uninstall`() {
         val installed = mutableListOf<String>()
         val lifecycle = lifecycle(
             debugActivities = setOf("debug"),
             installed = installed,
         )
-        lifecycle.resume("debug", Unit)
-        installed.clear()
-        lifecycle.pause("debug")
+        lifecycle.prepare("debug")
+        lifecycle.uninstall("debug")
 
-        lifecycle.toggle(true)
+        lifecycle.resume("debug", Unit)
 
         assertTrue(installed.isEmpty())
+        lifecycle.pause("debug")
         lifecycle.resume("debug", Unit)
         assertEquals(listOf("debug"), installed)
+    }
+
+    @Test
+    fun `manual-only uninstall does not suppress later resume`() {
+        val installed = mutableListOf<String>()
+        val lifecycle = lifecycle(installed = installed)
+        lifecycle.uninstall("manual")
+        lifecycle.toggle(true)
+
+        lifecycle.resume("manual", Unit)
+
+        assertEquals(listOf("manual"), installed)
+    }
+
+    @Test
+    fun `manual routing survives removal of latest entry`() {
+        val entries = linkedMapOf(
+            "first" to Entry("first", automatic = false),
+            "second" to Entry("second", automatic = false),
+        )
+
+        assertEquals("second", selectEntry(emptyList(), entries, Entry::automatic)?.id)
+        entries.remove("second")
+        assertEquals("first", selectEntry(emptyList(), entries, Entry::automatic)?.id)
+    }
+
+    @Test
+    fun `resumed automatic entry takes priority over manual fallback`() {
+        val entries = linkedMapOf(
+            "manual" to Entry("manual", automatic = false),
+            "first" to Entry("first", automatic = true),
+            "second" to Entry("second", automatic = true),
+        )
+
+        val active = selectEntry(
+            resumedActivities = listOf("first", "second"),
+            entries = entries,
+            isAutomatic = Entry::automatic,
+        )
+        val fallback = selectEntry(
+            resumedActivities = emptyList(),
+            entries = entries,
+            isAutomatic = Entry::automatic,
+        )
+
+        assertEquals("second", active?.id)
+        assertEquals("manual", fallback?.id)
     }
 
     @Test
@@ -143,6 +190,8 @@ class ScannerLifecycleTest {
         assertFalse(canResume(destroyed = true, state = RESUMED))
         assertFalse(canResume(destroyed = true, state = DESTROYED))
     }
+
+    private data class Entry(val id: String, val automatic: Boolean)
 
     private fun lifecycle(
         checkMainThread: () -> Unit = {},

--- a/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
@@ -56,6 +56,35 @@ class ScannerLifecycleTest {
     }
 
     @Test
+    fun `pause exposes previous resumed activity`() {
+        val lifecycle = lifecycle()
+        lifecycle.resume("first", Unit)
+        lifecycle.resume("second", Unit)
+
+        lifecycle.pause("second")
+
+        assertEquals(listOf("first"), lifecycle.resumedActivities())
+    }
+
+    @Test
+    fun `explicit uninstall is suppressed until next resume`() {
+        val installed = mutableListOf<String>()
+        val lifecycle = lifecycle(
+            debugActivities = setOf("debug"),
+            installed = installed,
+        )
+        lifecycle.resume("debug", Unit)
+        installed.clear()
+        lifecycle.uninstall("debug")
+
+        lifecycle.toggle(true)
+
+        assertTrue(installed.isEmpty())
+        lifecycle.resume("debug", Unit)
+        assertEquals(listOf("debug"), installed)
+    }
+
+    @Test
     fun `disable removes production installs`() {
         val installed = mutableListOf<String>()
         val lifecycle = lifecycle(installed = installed)

--- a/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
@@ -20,30 +20,7 @@ class ScannerLifecycleTest {
     }
 
     @Test
-    fun `enable before resume installs on resume`() {
-        val installed = mutableListOf<String>()
-        val lifecycle = lifecycle(installed = installed)
-
-        lifecycle.toggle(true)
-        lifecycle.resume("first", Unit)
-
-        assertEquals(listOf("first"), installed)
-    }
-
-    @Test
-    fun `enable after resume installs every resumed activity`() {
-        val installed = mutableListOf<String>()
-        val lifecycle = lifecycle(installed = installed)
-        lifecycle.resume("first", Unit)
-        lifecycle.resume("second", Unit)
-
-        lifecycle.toggle(true)
-
-        assertEquals(listOf("first", "second"), installed)
-    }
-
-    @Test
-    fun `paused activity is not reinstalled`() {
+    fun `toggle installs only resumed activities`() {
         val installed = mutableListOf<String>()
         val lifecycle = lifecycle(installed = installed)
         lifecycle.resume("first", Unit)
@@ -51,19 +28,10 @@ class ScannerLifecycleTest {
         lifecycle.pause("first")
 
         lifecycle.toggle(true)
+        lifecycle.resume("third", Unit)
 
-        assertEquals(listOf("second"), installed)
-    }
-
-    @Test
-    fun `pause exposes previous resumed activity`() {
-        val lifecycle = lifecycle()
-        lifecycle.resume("first", Unit)
-        lifecycle.resume("second", Unit)
-
-        lifecycle.pause("second")
-
-        assertEquals(listOf("first"), lifecycle.resumedActivities())
+        assertEquals(listOf("second", "third"), installed)
+        assertEquals(listOf("second", "third"), lifecycle.resumedActivities())
     }
 
     @Test
@@ -85,101 +53,57 @@ class ScannerLifecycleTest {
     }
 
     @Test
-    fun `manual-only uninstall does not suppress later resume`() {
-        val installed = mutableListOf<String>()
-        val lifecycle = lifecycle(installed = installed)
-        lifecycle.uninstall("manual")
-        lifecycle.toggle(true)
-
-        lifecycle.resume("manual", Unit)
-
-        assertEquals(listOf("manual"), installed)
-    }
-
-    @Test
-    fun `manual routing survives removal of latest entry`() {
-        val entries = linkedMapOf(
-            "first" to Entry("first", automatic = false),
-            "second" to Entry("second", automatic = false),
-        )
-
-        assertEquals("second", selectEntry(emptyList(), entries, Entry::automatic)?.id)
-        entries.remove("second")
-        assertEquals("first", selectEntry(emptyList(), entries, Entry::automatic)?.id)
-    }
-
-    @Test
-    fun `resumed automatic entry takes priority over manual fallback`() {
+    fun `manual routing falls back after removal`() {
         val entries = linkedMapOf(
             "manual" to Entry("manual", automatic = false),
             "first" to Entry("first", automatic = true),
             "second" to Entry("second", automatic = true),
         )
 
-        val active = selectEntry(
+        val automatic = selectEntry(
             resumedActivities = listOf("first", "second"),
             entries = entries,
             isAutomatic = Entry::automatic,
         )
-        val fallback = selectEntry(
-            resumedActivities = emptyList(),
-            entries = entries,
-            isAutomatic = Entry::automatic,
-        )
+        entries.remove("second")
+        entries.remove("first")
+        val manual = selectEntry(emptyList(), entries, Entry::automatic)
 
-        assertEquals("second", active?.id)
-        assertEquals("manual", fallback?.id)
+        assertEquals("second", automatic?.id)
+        assertEquals("manual", manual?.id)
     }
 
     @Test
-    fun `disable removes production installs`() {
+    fun `disable removes only production installs and is idempotent`() {
         val installed = mutableListOf<String>()
-        val lifecycle = lifecycle(installed = installed)
-        lifecycle.toggle(true)
-        lifecycle.resume("first", Unit)
-
-        lifecycle.toggle(false)
-
-        assertTrue(installed.isEmpty())
-        assertFalse(lifecycle.isAllowed(debuggable = false))
-    }
-
-    @Test
-    fun `debug activity remains installed when production is disabled`() {
-        val installed = mutableListOf<String>()
+        var removals = 0
         val lifecycle = lifecycle(
             debugActivities = setOf("debug"),
             installed = installed,
+            removeProd = {
+                removals++
+                installed.removeAll { it != "debug" }
+            },
         )
         lifecycle.resume("debug", Unit)
         lifecycle.toggle(true)
-        lifecycle.toggle(false)
+        lifecycle.resume("prod", Unit)
 
-        assertEquals(listOf("debug", "debug"), installed)
-    }
-
-    @Test
-    fun `repeated toggle is idempotent`() {
-        var removals = 0
-        val lifecycle = lifecycle(removeProd = { removals++ })
-
-        lifecycle.toggle(true)
-        lifecycle.toggle(true)
         lifecycle.toggle(false)
         lifecycle.toggle(false)
 
         assertEquals(1, removals)
+        assertEquals(listOf("debug", "debug"), installed)
+        assertFalse(lifecycle.isAllowed(debuggable = false))
     }
 
     @Test
     fun `worker thread rejection happens before state change`() {
-        var mainThread = false
-        val lifecycle = lifecycle(checkMainThread = { check(mainThread) })
+        val lifecycle = lifecycle(checkMainThread = { error("wrong thread") })
 
         assertThrows(IllegalStateException::class.java) {
             lifecycle.toggle(true)
         }
-
         assertFalse(lifecycle.isAllowed(debuggable = false))
     }
 

--- a/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/ScannerLifecycleTest.kt
@@ -67,7 +67,7 @@ class ScannerLifecycleTest {
     }
 
     @Test
-    fun `explicit uninstall is suppressed until next resume`() {
+    fun `removed activity is ignored until next resume`() {
         val installed = mutableListOf<String>()
         val lifecycle = lifecycle(
             debugActivities = setOf("debug"),
@@ -75,7 +75,7 @@ class ScannerLifecycleTest {
         )
         lifecycle.resume("debug", Unit)
         installed.clear()
-        lifecycle.uninstall("debug")
+        lifecycle.pause("debug")
 
         lifecycle.toggle(true)
 

--- a/scanner-ui/src/test/java/com/composea11yscanner/triggers/ScanTriggerExtensionsTest.kt
+++ b/scanner-ui/src/test/java/com/composea11yscanner/triggers/ScanTriggerExtensionsTest.kt
@@ -1,0 +1,60 @@
+package com.composea11yscanner.triggers
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.os.Looper
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadow.api.Shadow.newInstanceOf
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@LooperMode(LooperMode.Mode.PAUSED)
+class ScanTriggerExtensionsTest {
+    @Test
+    fun `disabled long press returns original modifier`() {
+        val modifier = Modifier
+
+        val result = modifier.scanOnLongPress(enabled = false) {
+            error("Disabled long press must not invoke its callback")
+        }
+
+        assertSame(modifier, result)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `disabled shake registers no sensor listener`() {
+        val activity = Robolectric.buildActivity(TestActivity::class.java).setup().get()
+        val sensorManager = activity.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        val shadowSensorManager = shadowOf(sensorManager)
+        shadowSensorManager.addSensor(
+            Sensor.TYPE_ACCELEROMETER,
+            newInstanceOf(Sensor::class.java),
+        )
+        val composeView = ComposeView(activity)
+        activity.setContentView(composeView)
+
+        composeView.setContent {
+            scanOnShake(enabled = false) {
+                error("Disabled shake must not invoke its callback")
+            }
+        }
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(shadowSensorManager.listeners.isEmpty())
+    }
+
+    class TestActivity : ComponentActivity()
+}


### PR DESCRIPTION
## Summary
- add an explicit, main-thread `toggleScanner(enabled)` policy for trusted non-debuggable use
- make explicit `false` override the debuggable default, remove every overlay, and block installation and scan APIs
- keep `uninstall()` cleanup-safe and idempotent after disable
- preserve automatic/manual routing, multi-resume handling, queued-uninstall protection, and safe built-in triggers
- document AndroidX Startup timing, synchronous policy application, retained runtime tracking, and the zero-overhead manifest hard opt-out
- add lifecycle and Robolectric regressions for disable, detach, routing cleanup, API guards, re-enable, and cleanup suppression

## Scanner availability contract
| State | Debuggable app | Non-debuggable app |
| --- | --- | --- |
| No `toggleScanner()` call | Enabled automatically | Denied |
| `toggleScanner(true)` | Enabled | Enabled |
| `toggleScanner(false)` | Disabled | Disabled |

`toggleScanner(false)` is a runtime control: it removes overlays and blocks scanner APIs while retaining lightweight AndroidX Startup callbacks and resumed-activity tracking so re-enable can install immediately. Variants requiring no scanner startup, metadata reads, lifecycle callbacks, or activity tracking can remove `A11yScannerInitializer` from the merged manifest as documented in the README.

Because AndroidX Startup runs before `Application.onCreate`, policies that default to disabled must call `toggleScanner(false)` synchronously from `Application.onCreate` before the first activity resumes. Asynchronous endpoint or remote-config resolution is explicitly discouraged.

## Safety and compatibility
- no existing public signature was removed or changed
- `toggleScanner(false)` is an intentional behavior correction relative to fork release `2.1.0-rt.3`: debug scanners now respect the explicit disable
- `uninstall()` now always performs main-thread cleanup, even after scanner permission is disabled
- positive allowlist and internal flavor/source-set guidance remains fail-closed

## Validation
- `test`
- `lint`
- `createDebugUnitTestCoverageReport`
- coverage threshold check: **91.9%** aggregate for `scanner-core` and `scanner-rules` (required 80%)
- `:sample:assembleRelease`
- `dokkaGenerate`
- `publishToMavenLocal` with `JITPACK_TAG=2.1.0-rt.4`
- generated POMs use `2.1.0-rt.4` for all modules and inter-module dependencies
- `git diff --check`

Final isolated Gradle validation completed successfully: **458 actionable tasks**.

## Review feedback addressed
- fail-closed trusted-build guidance now uses a positive allowlist and recommends internal variants/source sets
- integration coverage exercises the real Activity/overlay/controller wiring, queued resume protection, manual routing fallback, trigger behavior, detach cleanup, debug disable, and cleanup-safe uninstall
- runtime disable and manifest hard opt-out are now explicitly separated and documented